### PR TITLE
Feature: Lane Index Support

### DIFF
--- a/archiver/archiver.py
+++ b/archiver/archiver.py
@@ -802,11 +802,15 @@ class IngestArchiver:
                     message["dcp_bundle_uuid"] = manifest['bundleUuid']
 
                 if protocols.is_10x(self.ontology_api, data.get("library_preparation_protocol")):
+                    file_name = data['manifest_id']
+                    if "lane_index" in entity.data:
+                        file_name = f"{file_name}_{entity.data.get('lane_index')}"
+                    file_name = f"{file_name}.bam"
                     message["conversion"] = {}
-                    message["conversion"]["output_name"] = f"{data['manifest_id']}.bam"
+                    message["conversion"]["output_name"] = file_name
                     message["conversion"]["inputs"] = files
                     message["conversion"]["schema"] = protocols.map_10x_bam_schema(self.ontology_api, data.get("library_preparation_protocol"))
-                    message["files"] = [{"name": f"{data['manifest_id']}.bam"}]
+                    message["files"] = [{"name": file_name}]
 
                 messages.append(message)
 
@@ -932,23 +936,40 @@ class ArchiveEntityAggregator:
 
     def _get_sequencing_runs(self):
         process = self.manifest.get_assay_process()
-        archive_entity = ArchiveEntity()
-        archive_entity.manifest_id = self.manifest.manifest_id
-        archive_type = "sequencingRun"
-        archive_entity.archive_entity_type = archive_type
-        archive_entity.id = self.generate_archive_entity_id(archive_type, process)
-        archive_entity.data = {
-            'library_preparation_protocol': self.manifest.get_library_preparation_protocol(),
-            'process': self.manifest.get_assay_process(),
-            'files': self.manifest.get_files(),
-            'manifest_id': archive_entity.manifest_id
-        }
-        archive_entity.links = {
-            'assayRefs': [{
-                "alias": self.generate_archive_entity_id('sequencingExperiment', process)
-            }]
-        }
-        return [archive_entity]
+        files = self.manifest.get_files()
+        lanes = {}
+        # Index files by lane index
+        for file in files:
+            lane_index = file.get('content').get('lane_index',1)
+            if lane_index not in lanes:
+                lanes[lane_index] = []
+            lanes[lane_index].append(file)
+
+        archive_entities = []
+        for lane_index in lanes.keys():
+            lane_files = lanes.get(lane_index)
+
+            archive_entity = ArchiveEntity()
+            archive_entity.manifest_id = self.manifest.manifest_id
+            archive_type = "sequencingRun"
+            archive_entity.archive_entity_type = archive_type
+            archive_entity.id = self.generate_archive_entity_id(archive_type, process)
+            archive_entity.data = {
+                'library_preparation_protocol': self.manifest.get_library_preparation_protocol(),
+                'process': self.manifest.get_assay_process(),
+                'files': lane_files,
+                'manifest_id': archive_entity.manifest_id
+            }
+            archive_entity.links = {
+                'assayRefs': [{
+                    "alias": self.generate_archive_entity_id('sequencingExperiment', process)
+                }]
+            }
+            if len(lanes) > 1:
+                archive_entity.data['lane_index'] = lane_index
+                archive_entity.id = f'{archive_entity.id}_{lane_index}'
+            archive_entities.append(archive_entity)
+        return archive_entities
 
     def get_archive_entities(self, archive_entity_type):
         entities = []

--- a/archiver/ena.py
+++ b/archiver/ena.py
@@ -150,10 +150,10 @@ def convert_sequencing_run(hca_data: dict):
     mapper = JsonMapper(hca_data)
     converted_data = mapper.map({
         '$on': 'process',
-        'alias': ['uuid.uuid', prefix_with, _sq_run_alias_prefix],
+        #being overwritten 'alias': ['uuid.uuid', prefix_with, _sq_run_alias_prefix],
         'title': ['content.process_core.process_name', default_to, ''],
         'description': ['content.process_core.process_description', default_to, ''],
-        'assayRefs': ['uuid.uuid', _sq_run_assay_ref]
+        #being overwritten 'assayRefs': ['uuid.uuid', _sq_run_assay_ref]
     })
 
     converted_files = mapper.map({
@@ -185,8 +185,11 @@ def _sq_run_file_attributes(converted_files):
 
 def _sq_run_files(converted_files, hca_data):
     if protocols.is_10x(_ontology_api, hca_data.get("library_preparation_protocol")):
+        file_name = hca_data['manifest_id']
+        if 'lane_index' in hca_data:
+            file_name = f"{file_name}_{hca_data.get('lane_index')}"
         files = [{
-            'name': f"{hca_data['manifest_id']}.bam",
+            'name': f'{file_name}.bam',
             'type': 'bam'
         }]
     else:

--- a/archiver/instrument_model.py
+++ b/archiver/instrument_model.py
@@ -25,7 +25,7 @@ def _prepare_map():
     model_names = ['Illumina Genome Analyzer', 'Illumina Genome Analyzer II', 'Illumina Genome Analyzer IIx',
                    'Illumina HiSeq 2500', 'Illumina HiSeq 2000', 'Illumina HiSeq 1500', 'Illumina HiSeq 1000',
                    'Illumina MiSeq', 'Illumina HiScanSQ', 'HiSeq X Ten', 'NextSeq 500', 'HiSeq X Five',
-                   'Illumina HiSeq 3000', 'Illumina HiSeq 4000', 'NextSeq 550']
+                   'Illumina HiSeq 3000', 'Illumina HiSeq 4000', 'NextSeq 550', 'Illumina NovaSeq 6000']
     instrument_models = [illumina(name) for name in model_names]
     model_map = {model.hca_name: model for model in instrument_models}
 

--- a/archiver/instrument_model.py
+++ b/archiver/instrument_model.py
@@ -41,4 +41,4 @@ __instrument_model_map__ = _prepare_map()
 
 def to_dsp_name(hca_name: str):
     instrument_model = __instrument_model_map__.get(hca_name.lower())
-    return instrument_model.dsp_name if instrument_model else None
+    return instrument_model.dsp_name if instrument_model else 'unspecified'


### PR DESCRIPTION
Implementation for ticket [#93](https://github.com/ebi-ait/hca-ebi-dev-team/issues/93)
BAM conversion can only be performed by for a single lane.
When experiments contain more than one lane:
- Create an additional sequencing run per lane.
- Include lane index in sequencing run alias
- Include lane index in converted bam file name

Also includes fix for:
 - setting instrument model to `unspecified` if unsupported by DSP.
 - Adds support for `Illumina NovaSeq 6000`