### PR TITLE
Update archive entities with accessions

### DIFF
--- a/archiver/accessioner.py
+++ b/archiver/accessioner.py
@@ -75,7 +75,7 @@ class Accessioner:
         elif accession.accession_type == 'file':
             entity_patch['content']['insdc_run_accessions'] = [accession.accession_id]
 
-        entity_patch['validationState'] = 'Draft'
+        # TODO IMPORTANT!!! How to make sure that patching won't invalidate the json
 
         return entity_patch
 

--- a/archiver/submission.py
+++ b/archiver/submission.py
@@ -299,6 +299,12 @@ class ArchiveSubmission:
                 if entity:
                     entity.accession = accession
             elif result['status'] == 'Error':
+                alias = result['alias']
+                accession = result.get('accession')
+                accession_map[alias] = accession
+                entity = self.entity_map.find_entity(alias)
+                if entity:
+                    entity.accession = accession
                 self.add_error('archive_submission.complete.error',
                                f"There was an error submitting a " +
                                f"{result.get('submittableType', '')} with alias {result.get('alias', '')} to " +

--- a/cli.py
+++ b/cli.py
@@ -226,7 +226,7 @@ if __name__ == '__main__':
         entity_map = cli.build_map()
 
     if options.submission_url:
-        cli.complete_submission(options.submission_url, entity_map)
+        cli.complete_submission(options.submission_url)
     elif entity_map and not options.no_validation:
         cli.validate_submission(entity_map, options.submit, ingest_submission_uuid=options.ingest_submission_uuid)
 


### PR DESCRIPTION
This PR is needed to get the accessions back for the dataset in ticket ebi-ait/hca-ebi-wrangler-central#18
This also fixes the cli way to complete submission : ebi-ait/hca-ebi-dev-team#228

I've also removed the part when the archiver is setting the metadata to Draft again when it updates the accessions. This is causing the file validation to be triggered again.