### PR TITLE
Fix completing of dsp submission

### DIFF
--- a/api/dsp.py
+++ b/api/dsp.py
@@ -156,6 +156,7 @@ class DataSubmissionPortal:
 
     def _delete(self, delete_url):
         response = self.session.delete(delete_url, headers=self.get_headers())
+        response.raise_for_status()
 
         if response.ok:
             return True

--- a/api/ingest.py
+++ b/api/ingest.py
@@ -208,6 +208,17 @@ class IngestAPI:
         url = f'{self.url}/archiveSubmissions/search/findByDspUuid?dspUuid={dsp_uuid}'
         return self.get(url)
 
+    def get_latest_archive_submission_by_submission_uuid(self, submission_uuid):
+        search_url = f'{self.ingest_api_url}/archiveSubmissions/search/findBySubmissionUuid'
+        params = {
+            "submissionUuid": submission_uuid,
+            "sort": "created,desc"
+        }
+        data = self.session.get(search_url, params)
+        archive_submissions = data['_embedded']['archiveSubmissions']
+        archive_submission = archive_submissions[0] if len(archive_submissions) > 0 else None
+        return archive_submission
+
     def get_archive_entity_by_dsp_uuid(self, dsp_uuid):
         url = f'{self.url}/archiveEntities/search/findByDspUuid?dspUuid={dsp_uuid}'
         return self.get(url)
@@ -233,5 +244,10 @@ class IngestAPI:
 
     def put(self, url):
         r = self.session.put(url, headers=self.headers)
+        r.raise_for_status()
+        return r.json()
+
+    def delete(self, url):
+        r = self.session.delete(url, headers=self.headers)
         r.raise_for_status()
         return r.json()

--- a/api/ingest.py
+++ b/api/ingest.py
@@ -212,8 +212,7 @@ class IngestAPI:
 
     def get_archive_entity_by_archive_submission_url_and_alias(self, archive_submission_url: str, alias: str):
         url = f'{self.url}/archiveEntities/search/findByArchiveSubmissionAndAlias'
-        entities = self.get(url, params={'archiveSubmission': archive_submission_url, 'alias': alias})
-        return entities.get('_embedded', {}).get('archiveEntities', [])
+        return self.get(url, params={'archiveSubmission': archive_submission_url, 'alias': alias})
 
     def get(self, url, **kwargs):
         r = self.session.get(url, headers=self.headers, **kwargs)

--- a/api/ingest.py
+++ b/api/ingest.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 from typing import Iterator, List
+from urllib.parse import urlparse
 
 import requests
 from ingest.utils.s2s_token_client import S2STokenClient
@@ -168,7 +169,8 @@ class IngestAPI:
         return entity_id
 
     def entity_info_from_url(self, url):
-        location = str.replace(url, self.url, '').strip('/')
+        parsed_url = urlparse(url)
+        location = parsed_url.params.strip('/')
         entity_type = location.split('/')[0]
         entity_id = location.split('/')[1]
         return entity_type, entity_id

--- a/api/ingest.py
+++ b/api/ingest.py
@@ -170,7 +170,7 @@ class IngestAPI:
 
     def entity_info_from_url(self, url):
         parsed_url = urlparse(url)
-        location = parsed_url.params.strip('/')
+        location = parsed_url.path.strip('/')
         entity_type = location.split('/')[0]
         entity_id = location.split('/')[1]
         return entity_type, entity_id

--- a/api/ingest.py
+++ b/api/ingest.py
@@ -214,7 +214,7 @@ class IngestAPI:
             "submissionUuid": submission_uuid,
             "sort": "created,desc"
         }
-        data = self.get(search_url, params)
+        data = self.get(search_url, params=params)
         archive_submissions = data['_embedded']['archiveSubmissions']
         archive_submission = archive_submissions[0] if len(archive_submissions) > 0 else None
         return archive_submission

--- a/api/ingest.py
+++ b/api/ingest.py
@@ -214,7 +214,7 @@ class IngestAPI:
             "submissionUuid": submission_uuid,
             "sort": "created,desc"
         }
-        data = self.session.get(search_url, params)
+        data = self.get(search_url, params)
         archive_submissions = data['_embedded']['archiveSubmissions']
         archive_submission = archive_submissions[0] if len(archive_submissions) > 0 else None
         return archive_submission

--- a/api/ingest.py
+++ b/api/ingest.py
@@ -209,7 +209,7 @@ class IngestAPI:
         return self.get(url)
 
     def get_latest_archive_submission_by_submission_uuid(self, submission_uuid):
-        search_url = f'{self.ingest_api_url}/archiveSubmissions/search/findBySubmissionUuid'
+        search_url = f'{self.url}/archiveSubmissions/search/findBySubmissionUuid'
         params = {
             "submissionUuid": submission_uuid,
             "sort": "created,desc"

--- a/api/ingest.py
+++ b/api/ingest.py
@@ -210,9 +210,10 @@ class IngestAPI:
         url = f'{self.url}/archiveEntities/search/findByDspUuid?dspUuid={dsp_uuid}'
         return self.get(url)
 
-    def get_archive_entity_by_alias(self, alias):
-        url = f'{self.url}/archiveEntities/search/findByAlias?alias={alias}'
-        return self.get(url)
+    def get_archive_entity_by_archive_submission_url_and_alias(self, archive_submission_url: str, alias: str):
+        url = f'{self.url}/archiveEntities/search/findByArchiveSubmissionAndAlias'
+        entities = self.get(url, params={'archiveSubmission': archive_submission_url, 'alias': alias})
+        return entities.get('_embedded', {}).get('archiveEntities', [])
 
     def get(self, url, **kwargs):
         r = self.session.get(url, headers=self.headers, **kwargs)

--- a/app.py
+++ b/app.py
@@ -117,7 +117,7 @@ def get_latest_archive_submission(ingest_submission_uuid):
     latest_archive_submission = ingest_api.get_latest_archive_submission_by_submission_uuid(ingest_submission_uuid)
 
     if not latest_archive_submission:
-        return response_json(HTTPStatus.NOT_FOUND)
+        return response_json(HTTPStatus.NOT_FOUND, None)
 
     del latest_archive_submission['_links']
     return jsonify(latest_archive_submission)

--- a/app.py
+++ b/app.py
@@ -110,6 +110,19 @@ def async_archive(ingest_api: IngestAPI, archiver: IngestArchiver, submission_uu
         raise
 
 
+@app.route('/latestArchiveSubmission/<ingest_submission_uuid>')
+@require_apikey
+def get_latest_archive_submission(ingest_submission_uuid):
+    ingest_api = IngestAPI(config.INGEST_API_URL)
+    latest_archive_submission = ingest_api.get_latest_archive_submission_by_submission_uuid(ingest_submission_uuid)
+
+    if not latest_archive_submission:
+        return response_json(HTTPStatus.NOT_FOUND)
+
+    del latest_archive_submission['_links']
+    return jsonify(latest_archive_submission)
+
+
 @app.route('/archiveSubmissions/<dsp_submission_uuid>')
 @require_apikey
 def get_submission(dsp_submission_uuid: str):
@@ -117,6 +130,21 @@ def get_submission(dsp_submission_uuid: str):
     ingest_archive_submission = ingest_api.get_archive_submission_by_dsp_uuid(dsp_submission_uuid)
     del ingest_archive_submission['_links']
     return jsonify(ingest_archive_submission)
+
+
+@app.route('/archiveSubmissions/<dsp_submission_uuid>', methods=['DELETE'])
+@require_apikey
+def delete_archive_submission(dsp_submission_uuid: str):
+    ingest_api = IngestAPI(config.INGEST_API_URL)
+    dsp_api = DataSubmissionPortal(config.DSP_API_URL)
+    ingest_archive_submission = ingest_api.get_archive_submission_by_dsp_uuid(dsp_submission_uuid)
+    dsp_url = ingest_archive_submission['dspUrl']
+    dsp_api.delete_submission(dsp_url)
+    logger.info(f'Deleting DSP submission {dsp_url}')
+    archive_submission_url = ingest_archive_submission['_links']['self']['href']
+    logger.info(f'Deleting Ingest Archive Submission {archive_submission_url}')
+    response = ingest_api.delete(archive_submission_url)
+    return response_json(HTTPStatus.OK, data=response)
 
 
 @app.route('/archiveSubmissions/<dsp_submission_uuid>/fileUploadPlan', methods=['GET'])
@@ -180,26 +208,6 @@ def get_blockers(archive_submission_uuid: str):
     submission = ArchiveSubmission(dsp_api=dsp_api, dsp_submission_url=submission_url)
     blockers = submission.get_blockers()
     return jsonify(blockers)
-
-
-@app.route('/archiveSubmissions/<archive_submission_uuid>/submit', methods=['POST'])
-@require_apikey
-def submit(archive_submission_uuid: str):
-    dsp_api = DataSubmissionPortal(config.DSP_API_URL)
-    submission_url = dsp_api.get_submission_url(archive_submission_uuid)
-    submission = ArchiveSubmission(dsp_api=dsp_api, dsp_submission_url=submission_url)
-    if submission.is_submittable():
-        submission.submit()
-        data = {
-            'message': f'DSP Submission {submission.dsp_uuid} was submitted successfully'
-        }
-        return response_json(HTTPStatus.ACCEPTED, data=data)
-
-    data = {
-        'message': f'DSP submission {archive_submission_uuid} is not submittable.'
-                   f' Please make sure that the validation is passing and there are no submission blockers'
-    }
-    return response_json(HTTPStatus.BAD_REQUEST, data=data)
 
 
 @app.route('/archiveSubmissions/<dsp_submission_uuid>/complete', methods=['POST'])

--- a/archiver/archiver.py
+++ b/archiver/archiver.py
@@ -217,7 +217,9 @@ class IngestArchiver:
             dsp_submission_url = archive_submission.get_url()
             archive_submission.dsp_url = dsp_submission_url
             archive_submission.dsp_uuid = dsp_submission_url.rsplit('/', 1)[-1]
-            print(f"DSP SUBMISSION: {dsp_submission_url}")
+            output = f"DSP SUBMISSION: {dsp_submission_url}"
+            print(output)
+            self.logger.info(output)
             ingest_tracker = self.ingest_tracker
             ingest_tracker.create_archive_submission(archive_submission)
 
@@ -248,7 +250,7 @@ class IngestArchiver:
             archive_submission.is_completed = True
 
         archive_submission.process_result()
-        self.ingest_tracker.update_entities(entity_map)
+        self.ingest_tracker.update_entities(archive_submission.dsp_uuid, entity_map)
         self.accessioner.accession_entities(archive_submission.entity_map)
         self.ingest_tracker.set_submission_as_archived(archive_submission)
 


### PR DESCRIPTION
Changes:
1. Fix completing of DSP submission
- Broken because Core can now return multiple archive entities given an alias
- Fixed by finding archive entity uniquely by its alias and submission url
- A new endpoint in Core to find archive entity uniquely by its DSP alias and Ingest archive submission url 
(PR: https://github.com/ebi-ait/ingest-core/pull/35)

2. Additional endpoints for easy retrieving by ingest submission uuid and deleting DSP submissions


Ticket: ebi-ait/hca-ebi-dev-team#302