### PR TITLE
Archive Organ and Organ Part attributes to BioSamples

### DIFF
--- a/api/ontology.py
+++ b/api/ontology.py
@@ -6,12 +6,27 @@ import json
 
 from urllib.parse import quote
 
-
+# iri: "http://purl.obolibrary.org/obo/UBERON_0000948"
+# curie: "obo:UBERON_0000948"
+# label: "heart"
+# short_form: "UBERON_0000948"
+# obo_id: "UBERON:0000948"
 class OntologyAPI:
     def __init__(self, url=None):
         self.url = url if url else config.ONTOLOGY_API_URL
         self.logger = logging.getLogger(__name__)
         self.logger.info(f'Using {self.url}')
+
+    def iri_from_obo_id(self, obo_id):
+        term = self.find_by_id_defining(obo_id)
+        if term and 'iri' in term:
+            return term['iri']
+
+    def find_by_id_defining(self, obo_id):
+        query_url = f'{self.url}/api/terms/findByIdAndIsDefiningOntology?obo_id={obo_id}'
+        all_terms = self.get_all(query_url, 'terms')
+        if all_terms:
+            return all_terms[0]
 
     def expand_curie(self, term):
         iri = self.search_for_iri(term)

--- a/api/ontology.py
+++ b/api/ontology.py
@@ -25,7 +25,7 @@ class OntologyAPI:
         raise Error(f'Could not retrieve IRI for {term}')
 
     def search_for_iri(self, term, exact=True, obsolete=False, group=True, query_fields=None):
-        doc = self.search(term,exact,obsolete,group,query_fields)
+        doc = self.search(term, exact, obsolete, group, query_fields)
         return doc.get('iri') if doc else None
 
     def search(self, term, exact=True, obsolete=False, group=True, query_fields=None):
@@ -71,7 +71,7 @@ class OntologyAPI:
         results = []
         while query_url:
             response: dict = self.get_json(query_url)
-            results.extend(response.get('_embedded',{}).get(result_type,[]))
+            results.extend(response.get('_embedded', {}).get(result_type, []))
             query_url = response.get('_links', {}).get('next', {}).get('href', None)
         return results
 

--- a/archiver/biosamples.py
+++ b/archiver/biosamples.py
@@ -9,18 +9,18 @@ _ontology_api = ontology.__api__
 
 
 def format_ontology(*args):
-    if args[0] and 'ontology_label' in args[0] and 'ontology' in args[0]:
-        label: str = args[0]['ontology_label']
-        obo_id: str = args[0]['ontology']
-        iri = _ontology_api.iri_from_obo_id(obo_id)
-        if not iri:
-            short_form = obo_id.replace(':','_')
-            # Fallback ontology URL if no iri found
-            iri = f'http://purl.obolibrary.org/obo/{short_form}'
-        return [{
-            'value': label,
-            'terms': [{'url': iri}]
-        }]
+    if args[0]:
+        if 'ontology_label' in args[0] and 'ontology' in args[0]:
+            label: str = args[0]['ontology_label']
+            obo_id: str = args[0]['ontology']
+            iri = _ontology_api.iri_from_obo_id(obo_id)
+            if iri:
+                return [{
+                    'value': label,
+                    'terms': [{'url': iri}]
+                }]
+        if 'text' in args[0]:
+            return dsp_attribute(args[0]['text'])
 
 
 def _taxon(*args):

--- a/archiver/biosamples.py
+++ b/archiver/biosamples.py
@@ -76,6 +76,6 @@ def convert(hca_data: dict):
             converted_data['attributes']['Organ Part'] = format_ontology(organ_parts[0])
         elif len(organ_parts) > 1:
             for index, organ_part in enumerate(organ_parts):
-                converted_data['attributes']['Organ Part - {}'.format(index)] = format_ontology(organ_parts[index])
+                converted_data['attributes'][f'Organ Part - {index}'] = format_ontology(organ_parts[index])
 
     return converted_data

--- a/archiver/biosamples.py
+++ b/archiver/biosamples.py
@@ -1,20 +1,25 @@
 from copy import deepcopy
 
 from archiver.dsp_post_process import dsp_attribute, fixed_dsp_attribute, taxon_id
+from api import ontology
 from conversion.json_mapper import JsonMapper
 from conversion.post_process import format_date, default_to
 
-ontology_url = 'http://purl.obolibrary.org/obo/{}'
+_ontology_api = ontology.__api__
 
 
 def format_ontology(*args):
     if args[0] and 'ontology_label' in args[0] and 'ontology' in args[0]:
         label: str = args[0]['ontology_label']
-        ontology: str = args[0]['ontology']
-        url = ontology_url.format(ontology.replace(':','_'))
+        obo_id: str = args[0]['ontology']
+        iri = _ontology_api.iri_from_obo_id(obo_id)
+        if not iri:
+            short_form = obo_id.replace(':','_')
+            # Fallback ontology URL if no iri found
+            iri = f'http://purl.obolibrary.org/obo/{short_form}'
         return [{
             'value': label,
-            'terms': [{'url': url}]
+            'terms': [{'url': iri}]
         }]
 
 

--- a/archiver/biosamples.py
+++ b/archiver/biosamples.py
@@ -38,11 +38,11 @@ spec = {
     'title': ['biomaterial.content.biomaterial_core.biomaterial_name']
 }
 
-no_release_date_spec = deepcopy(spec)
-no_release_date_spec['releaseDate'] = ['biomaterial.submissionDate', format_date]
-
 
 def convert(hca_data: dict):
-    project = hca_data.get('project')
-    use_spec = spec if project and project.get('releaseDate') else no_release_date_spec
+    use_spec = deepcopy(spec)
+
+    if 'releaseDate' not in hca_data.get('project', {}):
+        use_spec['releaseDate'] = ['biomaterial.submissionDate', format_date]
+
     return JsonMapper(hca_data).map(use_spec)


### PR DESCRIPTION
Implements [dcp-ingest-central#60](https://github.com/ebi-ait/dcp-ingest-central/issues/60)
When converting biomaterials into DSP objects.
If the biomaterial is of type [specimen_from_organism](https://schema.humancellatlas.org/type/biomaterial/9.0.0/specimen_from_organism).

- [x] Add `Organ` to the DSP attributes object, mapped to the `biomaterial.content.organ`
- [x] Add `Organ Part` to the DSP attributes object, mapped to the `biomaterial.content.organ_parts`
- [x] If `organ_parts` contains more than one entry, map each to `Organ Part - Index` (e.g `Organ Part - 0`, `Organ Part - 1`)
- [x] All mappings will have to convert from the HCA ontology format to the DSP ontology format.
- [x] `obo_id`s are send to Ontology API to retrieve the correct defining `iri`
- [x] If no `iri` is found the DSP/Biosamples attribute is populates as a text object using the `text` attribute, rather than an ontology.

# Useful definitions
```
iri: "http://purl.obolibrary.org/obo/UBERON_0000948"
curie: "obo:UBERON_0000948"
label: "heart"
short_form: "UBERON_0000948"
obo_id: "UBERON:0000948"

HCA Ontology {
  text: free-text,
  ontology_label: label,
  ontology: obo_id
}
```
