### PR TITLE
dcp-447/Add direct submission flag for archive submission payload

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,6 +67,10 @@ def archive():
     submission_uuid = data.get('submission_uuid')
     exclude_types = data.get('exclude_types')
     alias_prefix = data.get('alias_prefix')
+    is_direct_archiving = data.get('is_direct_archiving')
+
+    if not is_direct_archiving:
+        is_direct_archiving = config.DIRECT_SUBMISSION
 
     if not submission_uuid:
         error = {
@@ -74,7 +78,7 @@ def archive():
         }
         return response_json(HTTPStatus.BAD_REQUEST, error)
 
-    if config.DIRECT_SUBMISSION:
+    if is_direct_archiving:
         direct_archiver = direct_archiver_from_config()
         submission = direct_archiver.archive_submission(submission_uuid)
         response = submission.as_dict(string_lists=True)

--- a/converter/biosamples.py
+++ b/converter/biosamples.py
@@ -60,4 +60,9 @@ class BioSamplesConverter:
 
     @staticmethod
     def __convert_datetime(datetime_str: str) -> datetime:
-        return datetime.strptime(datetime_str, '%Y-%m-%dT%H:%M:%S.%fZ')
+        if datetime_str:
+            if '.' in datetime_str:
+                datetime_format = '%Y-%m-%dT%H:%M:%S.%fZ'
+            else:
+                datetime_format = '%Y-%m-%dT%H:%M:%SZ'
+            return datetime.strptime(datetime_str, datetime_format)


### PR DESCRIPTION
dcp-447

Changes:
- Put back the original date time conversion for the BioSamples sample converter
- Check if the `is_direct_archive` key exists in the archive submission payload and act accordingly. When the whole direct submission to archives implemented and we retire DSP then this checking could be removed.