### PR TITLE
Temporary switch off Biostudies direct archiving

### DIFF
--- a/archiver/direct.py
+++ b/archiver/direct.py
@@ -37,9 +37,10 @@ class DirectArchiver:
         if self.__biosamples_submitter:
             biosamples = self.__biosamples_submitter.send_all_samples(submission)
             ingest_entities_to_update.extend(biosamples.get(CREATED_ENTITY, []))
-        if self.__biostudies_submitter:
-            biostudies = self.__biostudies_submitter.send_all_projects(submission)
-            ingest_entities_to_update.extend(biostudies.get(CREATED_ENTITY, []))
+        # TODO dcp-ingest-central/448 BST Test env is not exposed to outside of EBI VPN
+        # if self.__biostudies_submitter:
+        #     biostudies = self.__biostudies_submitter.send_all_projects(submission)
+        #     ingest_entities_to_update.extend(biostudies.get(CREATED_ENTITY, []))
         for entity in ingest_entities_to_update:
             submission.add_accessions_to_attributes(entity)
             self.__updater.update_entity(entity)

--- a/config.py
+++ b/config.py
@@ -47,6 +47,6 @@ ONTOLOGY_API_URL = os.environ.get('ONTOLOGY_API_URL', 'https://ontology.staging.
 DIRECT_SUBMISSION = os.environ.get('DIRECT_SUBMISSION', False)
 BIOSAMPLES_URL = os.environ.get('BIOSAMPLES_URL', 'https://wwwdev.ebi.ac.uk/biosamples')
 
-BIOSTUDIES_URL = os.environ.get('BIOSAMPLES_URL', 'http://biostudy-bia.ebi.ac.uk:8788')
+BIOSTUDIES_URL = os.environ.get('BIOSTUDIES_API_URL', 'http://biostudy-dev:8788')
 BIOSTUDIES_USERNAME = os.environ.get('BIOSTUDIES_USERNAME')
 BIOSTUDIES_PASSWORD = os.environ.get('BIOSTUDIES_PASSWORD')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 assertpy~=1.1
 biosamples_client~=1.3.0
+biostudies-client~=0.1.4
 xmltodict~=0.12.0
 submission_broker~=0.1.1
 polling==0.3.1


### PR DESCRIPTION
Changes:
- Temporary switch off Biostudies direct archiving as BioStudies test environment not exposed to outside EBI VPN. That means ingest-archiver can't communicate with BioStudies API on test env.

This temporary change would fix the current failure in the integration test on dev environment.