### PR TITLE
[dcp-497] Move deployment env method param to config

### DIFF
--- a/app.py
+++ b/app.py
@@ -68,7 +68,6 @@ def archive():
     exclude_types = data.get('exclude_types')
     alias_prefix = data.get('alias_prefix')
     is_direct_archiving = data.get('is_direct_archiving')
-    deployment_env = data.get('deployment_env')
 
     if not is_direct_archiving:
         is_direct_archiving = config.DIRECT_SUBMISSION
@@ -80,7 +79,7 @@ def archive():
         return response_json(HTTPStatus.BAD_REQUEST, error)
 
     if is_direct_archiving:
-        direct_archiver = direct_archiver_from_config(deployment_env)
+        direct_archiver = direct_archiver_from_config()
         submission = direct_archiver.archive_submission(submission_uuid)
         response = submission.as_dict(string_lists=True)
     else:

--- a/archiver/direct.py
+++ b/archiver/direct.py
@@ -16,8 +16,7 @@ from submitter.biostudies_submitter_service import BioStudiesSubmitterService
 
 
 class DirectArchiver:
-    def __init__(self, loader: HcaLoader, updater: HcaUpdater,
-                 biosamples_submitter: BioSamplesSubmitter = None,
+    def __init__(self, loader: HcaLoader, updater: HcaUpdater, biosamples_submitter: BioSamplesSubmitter = None,
                  biostudies_submitter: BioStudiesSubmitter = None):
         self.__loader = loader
         self.__updater = updater

--- a/config.py
+++ b/config.py
@@ -47,6 +47,8 @@ ONTOLOGY_API_URL = os.environ.get('ONTOLOGY_API_URL', 'https://ontology.staging.
 DIRECT_SUBMISSION = os.environ.get('DIRECT_SUBMISSION', False)
 BIOSAMPLES_URL = os.environ.get('BIOSAMPLES_URL', 'https://wwwdev.ebi.ac.uk/biosamples')
 
+BIOSTUDIES_ENV = 'dev'
 BIOSTUDIES_URL = os.environ.get('BIOSTUDIES_API_URL', 'http://biostudy-dev:8788')
+BIOSTUDIES_STUDY_URL = os.environ.get('BIOSTUDIES_STUDY_URL', 'https://wwwdev.ebi.ac.uk/biostudies/studies/')
 BIOSTUDIES_USERNAME = os.environ.get('BIOSTUDIES_API_USERNAME')
 BIOSTUDIES_PASSWORD = os.environ.get('BIOSTUDIES_API_PASSWORD')

--- a/submitter/biosamples_submitter_service.py
+++ b/submitter/biosamples_submitter_service.py
@@ -1,14 +1,14 @@
 from submission_broker.services.biosamples import BioSamples
 from submission_broker.submission.entity import Entity
 
-BIOSTUDIES_STUDY_LINK = 'https://www{}.ebi.ac.uk/biostudies/studies/'
+from config import BIOSTUDIES_STUDY_URL
 
 
 class BioSamplesSubmitterService:
 
-    def __init__(self, archive_client: BioSamples, deployment_env: str):
+    def __init__(self, archive_client: BioSamples):
         self.__archive_client = archive_client
-        self.__deployment_env = 'dev' if deployment_env.lower() in ('dev', 'staging') else ''
+        self.__study_link = BIOSTUDIES_STUDY_URL
 
     def update_sample_with_biostudies_accession(self, entity: Entity, biostudies_accession: str):
         if biostudies_accession is None:
@@ -20,7 +20,7 @@ class BioSamplesSubmitterService:
         return {
             'externalReferences': [
                 {
-                    'url': BIOSTUDIES_STUDY_LINK.format(self.__deployment_env) + accession
+                    'url': self.__study_link + accession
                 }
             ]
         }

--- a/tests/unit/submitter/test_biosamples_submitter.py
+++ b/tests/unit/submitter/test_biosamples_submitter.py
@@ -18,8 +18,7 @@ class TestBioSamplesSubmitter(unittest.TestCase):
         self.converter = MagicMock()
         self.empty_sample = Sample(ncbi_taxon_id=9606)
         self.converter.convert = MagicMock(return_value=self.empty_sample)
-        self.env = 'dev'
-        self.submitter_service = BioSamplesSubmitterService(self.biosamples_client, self.env)
+        self.submitter_service = BioSamplesSubmitterService(self.biosamples_client)
         self.submitter = BioSamplesSubmitter(self.biosamples_client, self.converter, self.submitter_service)
         self.submitter._submit_to_archive = MagicMock()
         self.submission = HcaSubmission()

--- a/tests/unit/submitter/test_biosamples_submitter_service.py
+++ b/tests/unit/submitter/test_biosamples_submitter_service.py
@@ -12,8 +12,7 @@ class BioSamplesSubmitterServiceTest(unittest.TestCase):
 
     def setUp(self) -> None:
         self.archive_client = MagicMock()
-        self.env = 'dev'
-        self.submitter_service = BioSamplesSubmitterService(self.archive_client, self.env)
+        self.submitter_service = BioSamplesSubmitterService(self.archive_client)
 
         with open(dirname(__file__) + '/../../resources/biomaterial_entity.json') as file:
             self.biomaterial: Entity = Entity('biomaterials', 0, attributes=json.load(file))


### PR DESCRIPTION
ebi-ait/dcp-ingest-central#497

Changes:
- Removed deployment env parameter from `archiveSubmissions ` payload
- Add BIOSTUDIES_STUDY_URL and BIOSTUDIES_ENV to the config. BIOSTUDIES_ENV can be removed later when we tested that BioStudies backend can be accessible externally.