### PR TITLE
[dcp-497/448] Removing condition as BST exposed their services in TEST env

### DIFF
--- a/archiver/direct.py
+++ b/archiver/direct.py
@@ -37,7 +37,7 @@ class DirectArchiver:
         ingest_entities_to_update = []
         if self.__biosamples_submitter:
             biosample_accessions = self.__archive_samples_to_biosamples(ingest_entities_to_update, submission)
-        # TODO dcp-ingest-central/448 BST Test env is not exposed to outside of EBI VPN
+
         if self.__biostudies_submitter:
             biostudies_accessions = self.__archive_project_to_biostudies(ingest_entities_to_update, submission)
 
@@ -69,7 +69,6 @@ class DirectArchiver:
                                                                              biostudies_accession)
         self.__biosamples_submitter.update_samples_with_biostudies_accession(submission, biosample_accessions,
                                                                              biostudies_accession)
-        # TODO add biostudies accession to samples in ebi-ait/dcp-ingest-central#497
 
 
 def direct_archiver_from_params(
@@ -87,14 +86,10 @@ def direct_archiver_from_params(
     biosamples_submitter_service = BioSamplesSubmitterService(biosamples_client)
     biosamples_submitter = BioSamplesSubmitter(biosamples_client, biosamples_converter, biosamples_submitter_service)
 
-    # TODO when we solved the issue with BioStudies availability, then we can remove the above condition
-    if config.BIOSTUDIES_ENV == 'dev':
-        biostudies_converter = BioStudiesConverter()
-        biostudies_client = BioStudies(biostudies_url, biostudies_username, biostudies_password)
-        biostudies_submitter_service = BioStudiesSubmitterService(biostudies_client)
-        biostudies_submitter = BioStudiesSubmitter(biostudies_client, biostudies_converter, biostudies_submitter_service)
-    else:
-        biostudies_submitter = None
+    biostudies_converter = BioStudiesConverter()
+    biostudies_client = BioStudies(biostudies_url, biostudies_username, biostudies_password)
+    biostudies_submitter_service = BioStudiesSubmitterService(biostudies_client)
+    biostudies_submitter = BioStudiesSubmitter(biostudies_client, biostudies_converter, biostudies_submitter_service)
 
     return DirectArchiver(loader=hca_loader, updater=hca_updater,
                           biosamples_submitter=biosamples_submitter,

--- a/config.py
+++ b/config.py
@@ -47,7 +47,6 @@ ONTOLOGY_API_URL = os.environ.get('ONTOLOGY_API_URL', 'https://ontology.staging.
 DIRECT_SUBMISSION = os.environ.get('DIRECT_SUBMISSION', False)
 BIOSAMPLES_URL = os.environ.get('BIOSAMPLES_URL', 'https://wwwdev.ebi.ac.uk/biosamples')
 
-BIOSTUDIES_ENV = 'dev'
 BIOSTUDIES_URL = os.environ.get('BIOSTUDIES_API_URL', 'https://wwwdev.ebi.ac.uk/biostudies/submissions/api')
 BIOSTUDIES_STUDY_URL = os.environ.get('BIOSTUDIES_STUDY_URL', 'https://wwwdev.ebi.ac.uk/biostudies/studies/')
 BIOSTUDIES_USERNAME = os.environ.get('BIOSTUDIES_API_USERNAME')

--- a/config.py
+++ b/config.py
@@ -48,7 +48,7 @@ DIRECT_SUBMISSION = os.environ.get('DIRECT_SUBMISSION', False)
 BIOSAMPLES_URL = os.environ.get('BIOSAMPLES_URL', 'https://wwwdev.ebi.ac.uk/biosamples')
 
 BIOSTUDIES_ENV = 'dev'
-BIOSTUDIES_URL = os.environ.get('BIOSTUDIES_API_URL', 'http://biostudy-dev:8788')
+BIOSTUDIES_URL = os.environ.get('BIOSTUDIES_API_URL', 'https://wwwdev.ebi.ac.uk/biostudies/submissions/api')
 BIOSTUDIES_STUDY_URL = os.environ.get('BIOSTUDIES_STUDY_URL', 'https://wwwdev.ebi.ac.uk/biostudies/studies/')
 BIOSTUDIES_USERNAME = os.environ.get('BIOSTUDIES_API_USERNAME')
 BIOSTUDIES_PASSWORD = os.environ.get('BIOSTUDIES_API_PASSWORD')


### PR DESCRIPTION
ebi-ait/dcp-ingest-central#497
ebi-ait/dcp-ingest-central#448

Changes:
- Removed condition that checking the deployment environment as BioStudies already exposed their test services