### PR TITLE
[dcp-541] Fix biostudies spec

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO,
 
 logging.getLogger('archiver').setLevel(logging.INFO)
 logging.getLogger('api').setLevel(logging.INFO)
+logging.getLogger('converter').setLevel(logging.INFO)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/app.py
+++ b/app.py
@@ -24,7 +24,6 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO,
 
 logging.getLogger('archiver').setLevel(logging.INFO)
 logging.getLogger('api').setLevel(logging.INFO)
-logging.getLogger('converter').setLevel(logging.INFO)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/converter/biostudies.py
+++ b/converter/biostudies.py
@@ -8,51 +8,10 @@ ACCNO_PREFIX_FOR_ORGANIZATIONS = "o"
 
 ACCNO_PREFIX_FOR_AUTHORS = "a"
 
-PROJECT_SPEC_BASE = [
-    {
-        'name': ['', default_to, 'Project Core - Project Short Name'],
-        'value': ['content.project_core.project_short_name']
-    },
-    {
-        'name': ['', default_to, 'HCA Project UUID'],
-        'value': ['uuid.uuid']
-    },
-    {
-        'name': ['', default_to, 'ReleaseDate'],
-        'value': ['releaseDate']
-    }
-]
 
 def array_to_string(*args):
     value = ", ".join(args[0])
     return value
-
-
-PROJECT_SPEC_PUBLICATIONS = {
-    "type": ['', default_to, "Publication"],
-    "$on": 'publications',
-    "attributes": ['$array', [
-            {
-                "name": ['', default_to, "Authors"],
-                "value": ['authors', array_to_string]
-            },
-            {
-                "name": ['', default_to, "Title"],
-                "value": ['title']
-            },
-            {
-                "name": ['', default_to, "doi"],
-                "value": ['doi']
-            },
-            {
-                "name": ['', default_to, "URL"],
-                "value": ['url']
-            }
-        ],
-        True
-    ]
-}
-
 
 def _parse_name(*args):
     full_name = args[0]
@@ -65,69 +24,6 @@ def _parse_name(*args):
     return name_element[0] if name_element and position == 1 else name_element
 
 
-PROJECT_SPEC_AUTHORS = {
-    "type": ['', default_to, "Author"],
-    "$on": 'contributors',
-    "attributes": ['$array', [
-            {
-                "name": ['', default_to, "Name"],
-                "value": ['name']
-            },
-            {
-                "name": ['', default_to, "First Name"],
-                "value": ['name', _parse_name, 0]
-            },
-            {
-                "name": ['', default_to, "Middle Initials"],
-                "value": ['name', _parse_name, 1]
-            },
-            {
-                "name": ['', default_to, "Last Name"],
-                "value": ['name', _parse_name, 2]
-            },
-            {
-                "name": ['', default_to, "Email"],
-                "value": ['email']
-            },
-            {
-                "name": ['', default_to, "Phone"],
-                "value": ['phone']
-            },
-            {
-                "name": ['', default_to, "Address"],
-                "value": ['address']
-            },
-            {
-                "name": ['', default_to, "Orcid ID"],
-                "value": ['orcid_id']
-            },
-    ],
-        True
-    ]
-}
-
-PROJECT_SPEC_FUNDINGS = {
-    "type": ['', default_to, "Funding"],
-    "$on": 'funders',
-    "attributes": ['$array', [
-            {
-                "name": ['', default_to, "grant_id"],
-                "value": ['grant_id']
-            },
-            {
-                "name": ['', default_to, "Grant Title"],
-                "value": ['grant_title']
-            },
-            {
-                "name": ['', default_to, "Agency"],
-                "value": ['organization']
-            },
-    ],
-        True
-    ]
-}
-
-
 class BioStudiesConverter:
 
     def __init__(self):
@@ -136,6 +32,20 @@ class BioStudiesConverter:
         self.contributors = None
         self.funders = None
         self.publications = None
+        self.project_spec_base = [
+            {
+                'name': ['', default_to, 'Project Core - Project Short Name'],
+                'value': ['content.project_core.project_short_name']
+            },
+            {
+                'name': ['', default_to, 'HCA Project UUID'],
+                'value': ['uuid.uuid']
+            },
+            {
+                'name': ['', default_to, 'ReleaseDate'],
+                'value': ['releaseDate']
+            }
+        ]
         self.project_spec_section = {
             "accno": ['', default_to, "PROJECT"],
             "type": ['', default_to, "Study"],
@@ -152,17 +62,101 @@ class BioStudiesConverter:
                 True
             ]
         }
+        self.project_spec_publications = {
+            "type": ['', default_to, "Publication"],
+            "$on": 'publications',
+            "attributes": ['$array', [
+                {
+                    "name": ['', default_to, "Authors"],
+                    "value": ['authors', array_to_string]
+                },
+                {
+                    "name": ['', default_to, "Title"],
+                    "value": ['title']
+                },
+                {
+                    "name": ['', default_to, "doi"],
+                    "value": ['doi']
+                },
+                {
+                    "name": ['', default_to, "URL"],
+                    "value": ['url']
+                }
+            ],
+                           True
+                           ]
+        }
+        self.project_spec_authors = {
+            "type": ['', default_to, "Author"],
+            "$on": 'contributors',
+            "attributes": ['$array', [
+                    {
+                        "name": ['', default_to, "Name"],
+                        "value": ['name']
+                    },
+                    {
+                        "name": ['', default_to, "First Name"],
+                        "value": ['name', _parse_name, 0]
+                    },
+                    {
+                        "name": ['', default_to, "Middle Initials"],
+                        "value": ['name', _parse_name, 1]
+                    },
+                    {
+                        "name": ['', default_to, "Last Name"],
+                        "value": ['name', _parse_name, 2]
+                    },
+                    {
+                        "name": ['', default_to, "Email"],
+                        "value": ['email']
+                    },
+                    {
+                        "name": ['', default_to, "Phone"],
+                        "value": ['phone']
+                    },
+                    {
+                        "name": ['', default_to, "Address"],
+                        "value": ['address']
+                    },
+                    {
+                        "name": ['', default_to, "Orcid ID"],
+                        "value": ['orcid_id']
+                    },
+            ],
+                True
+            ]
+        }
+        self.project_spec_fundings = {
+            "type": ['', default_to, "Funding"],
+            "$on": 'funders',
+            "attributes": ['$array', [
+                    {
+                        "name": ['', default_to, "grant_id"],
+                        "value": ['grant_id']
+                    },
+                    {
+                        "name": ['', default_to, "Grant Title"],
+                        "value": ['grant_title']
+                    },
+                    {
+                        "name": ['', default_to, "Agency"],
+                        "value": ['organization']
+                    },
+            ],
+                True
+            ]
+        }
 
     def convert(self, hca_project: dict, additional_attributes: dict = None) -> dict:
         if hca_project:
             self.logger.info(f'hca_project: {json.dumps(hca_project)}')
-            self.logger.info(f'PROJECT_SPEC_BASE: {PROJECT_SPEC_BASE}')
+            self.logger.info(f'PROJECT_SPEC_BASE: {self.project_spec_base}')
             self.logger.info(f'PROJECT_SPEC_SECTION: {self.project_spec_section}')
         else:
             self.logger.info(f'hca_project is falsy')
 
         converted_project = JsonMapper(hca_project).map({
-            'attributes': ['$array', PROJECT_SPEC_BASE, True],
+            'attributes': ['$array', self.project_spec_base, True],
             'section': self.project_spec_section
             })
 
@@ -172,23 +166,22 @@ class BioStudiesConverter:
 
         return converted_project
 
-    @staticmethod
-    def __add_subsections_to_project(converted_project, project_content):
+    def __add_subsections_to_project(self, converted_project, project_content):
         contributors = project_content.get('contributors')
         funders = project_content.get('funders')
         publications = project_content.get('publications')
         if contributors or funders or publications:
             converted_project['section']['subsections'] = []
 
-        converted_publications = JsonMapper(project_content).map(PROJECT_SPEC_PUBLICATIONS) if publications else []
+        converted_publications = JsonMapper(project_content).map(self.project_spec_publications) if publications else []
 
         converted_organizations = []
 
-        converted_authors = JsonMapper(project_content).map(PROJECT_SPEC_AUTHORS) if contributors else []
+        converted_authors = JsonMapper(project_content).map(self.project_spec_authors) if contributors else []
         BioStudiesConverter.__add_accno(converted_authors, ACCNO_PREFIX_FOR_AUTHORS)
         BioStudiesConverter.__add_affiliation(contributors, converted_authors, converted_organizations)
 
-        converted_funders = JsonMapper(project_content).map(PROJECT_SPEC_FUNDINGS) if funders else []
+        converted_funders = JsonMapper(project_content).map(self.project_spec_fundings) if funders else []
 
         converted_project['section']['subsections'] = \
             converted_publications + converted_authors + converted_organizations + converted_funders

--- a/converter/biostudies.py
+++ b/converter/biostudies.py
@@ -1,3 +1,6 @@
+import json
+import logging
+
 from json_converter.json_mapper import JsonMapper
 from json_converter.post_process import default_to
 
@@ -128,6 +131,7 @@ PROJECT_SPEC_FUNDINGS = {
 class BioStudiesConverter:
 
     def __init__(self):
+        self.logger = logging.getLogger(__name__)
         self.attributes = None
         self.contributors = None
         self.funders = None
@@ -150,6 +154,13 @@ class BioStudiesConverter:
         }
 
     def convert(self, hca_project: dict, additional_attributes: dict = None) -> dict:
+        if hca_project:
+            self.logger.info(f'hca_project: {json.dumps(hca_project)}')
+            self.logger.info(f'PROJECT_SPEC_BASE: {PROJECT_SPEC_BASE}')
+            self.logger.info(f'PROJECT_SPEC_SECTION: {self.project_spec_section}')
+        else:
+            self.logger.info(f'hca_project is falsy')
+
         converted_project = JsonMapper(hca_project).map({
             'attributes': ['$array', PROJECT_SPEC_BASE, True],
             'section': self.project_spec_section

--- a/converter/biostudies.py
+++ b/converter/biostudies.py
@@ -27,7 +27,6 @@ def _parse_name(*args):
 class BioStudiesConverter:
 
     def __init__(self):
-        self.logger = logging.getLogger(__name__)
         self.attributes = None
         self.contributors = None
         self.funders = None
@@ -148,13 +147,6 @@ class BioStudiesConverter:
         }
 
     def convert(self, hca_project: dict, additional_attributes: dict = None) -> dict:
-        if hca_project:
-            self.logger.info(f'hca_project: {json.dumps(hca_project)}')
-            self.logger.info(f'PROJECT_SPEC_BASE: {self.project_spec_base}')
-            self.logger.info(f'PROJECT_SPEC_SECTION: {self.project_spec_section}')
-        else:
-            self.logger.info(f'hca_project is falsy')
-
         converted_project = JsonMapper(hca_project).map({
             'attributes': ['$array', self.project_spec_base, True],
             'section': self.project_spec_section

--- a/converter/biostudies.py
+++ b/converter/biostudies.py
@@ -1,6 +1,3 @@
-import json
-import logging
-
 from json_converter.json_mapper import JsonMapper
 from json_converter.post_process import default_to
 

--- a/converter/biostudies.py
+++ b/converter/biostudies.py
@@ -20,24 +20,6 @@ PROJECT_SPEC_BASE = [
     }
 ]
 
-PROJECT_SPEC_SECTION = {
-    "accno": ['', default_to, "PROJECT"],
-    "type": ['', default_to, "Study"],
-    "attributes": ['$array', [
-            {
-                "name": ['', default_to, "Title"],
-                "value": ['content.project_core.project_title']
-            },
-            {
-                "name": ['', default_to, "Description"],
-                "value": ['content.project_core.project_description']
-            }
-        ],
-        True
-    ]
-}
-
-
 def array_to_string(*args):
     value = ", ".join(args[0])
     return value
@@ -150,11 +132,27 @@ class BioStudiesConverter:
         self.contributors = None
         self.funders = None
         self.publications = None
+        self.project_spec_section = {
+            "accno": ['', default_to, "PROJECT"],
+            "type": ['', default_to, "Study"],
+            "attributes": ['$array', [
+                    {
+                        "name": ['', default_to, "Title"],
+                        "value": ['content.project_core.project_title']
+                    },
+                    {
+                        "name": ['', default_to, "Description"],
+                        "value": ['content.project_core.project_description']
+                    }
+                ],
+                True
+            ]
+        }
 
     def convert(self, hca_project: dict, additional_attributes: dict = None) -> dict:
         converted_project = JsonMapper(hca_project).map({
             'attributes': ['$array', PROJECT_SPEC_BASE, True],
-            'section': PROJECT_SPEC_SECTION
+            'section': self.project_spec_section
             })
 
         project_content = hca_project['content'] if 'content' in hca_project else None

--- a/tests/unit/converter/test_biostudies_converter.py
+++ b/tests/unit/converter/test_biostudies_converter.py
@@ -22,6 +22,17 @@ class TestBioStudiesConverter(unittest.TestCase):
         self.assertEqual(json.dumps(expected_payload, sort_keys=True, indent=2),
                          json.dumps(converted_payload, sort_keys=True, indent=2))
 
+    def test_given_ingest_project_converts_project_twice_should_return_correct_biostudies_payload(self):
+        self.maxDiff = None
+        expected_payload = self.__get_expected_payload()
+        biostudies_converter2 = BioStudiesConverter()
+
+        self.biostudies_converter.convert(self.project['attributes'])
+        converted_payload = biostudies_converter2.convert(self.project['attributes'])
+
+        self.assertEqual(json.dumps(expected_payload, sort_keys=True, indent=2),
+                         json.dumps(converted_payload, sort_keys=True, indent=2))
+
     @staticmethod
     def __get_expected_payload():
         with open(dirname(__file__) + '/../../resources/expected_biostudies_payload.json') as file:


### PR DESCRIPTION
dcp-541

Changes:
- Move project specification for JSON Mapper into the `_init_` method of `BioStudies` converter. Before this change the GLOBAL spec objects are being reused and were modified by the conversion. We have to use clean specs every time when we start a conversion.