### PR TITLE
[dcp-557] Improve BioStudies error reporting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,12 @@ COPY converter ./converter
 COPY hca ./hca
 COPY submitter ./submitter
 COPY utils ./utils
-COPY config.py app.py requirements.txt ./
+COPY config.py archiver_app.py requirements.txt ./
 
 RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 
 EXPOSE 5000
 
-ENTRYPOINT ["python", "app.py"]
+ENTRYPOINT ["python", "archiver_app.py"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 assertpy~=1.1
 biosamples_client~=1.3.0
-biostudies-client~=0.1.4
+biostudies-client~=0.1.5
 xmltodict~=0.12.0
 submission_broker~=0.1.2
 polling==0.3.1

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -13,7 +13,7 @@ COPY hca ./hca
 COPY submitter ./submitter
 COPY utils ./utils
 COPY tests ./tests
-COPY config.py app.py requirements.txt requirements-dev.txt ./
+COPY config.py archiver_app.py requirements.txt requirements-dev.txt ./
 
 RUN pip install --upgrade pip
 RUN pip install -r requirements-dev.txt

--- a/tests/unit/test_archiver_app.py
+++ b/tests/unit/test_archiver_app.py
@@ -1,0 +1,56 @@
+import unittest
+from http import HTTPStatus
+from unittest.mock import patch
+from assertpy import assert_that
+from biostudiesclient.exceptions import RestErrorException
+
+import archiver_app
+from archiver_app import app as _app
+
+request_ctx = _app.test_request_context()
+request_ctx.push()
+
+
+class ArchiverAppTest(unittest.TestCase):
+    def setUp(self):
+        _app.testing = True
+        self.app = _app.test_client()
+
+    @patch('archiver_app.request')
+    @patch('archiver_app.config')
+    @patch('archiver.direct.direct_archiver_from_config')
+    def test_when_archive_respond_with_error_then_direct_archiving_returns_the_error_message(
+            self, mock_direct_archiver_from_config, mock_config, mock_request):
+        # given
+        request_timeout_status = HTTPStatus.REQUEST_TIMEOUT
+        error_message = 'Request timed out.'
+        archive_failed_message = 'Archiving failed.'
+        mock_direct_archiver_from_config.side_effect = RestErrorException(error_message, request_timeout_status)
+        archiver_app.direct_archiver_from_config = mock_direct_archiver_from_config
+        api_key = 'API-KEY'
+        mock_config.ARCHIVER_API_KEY = api_key
+
+        mock_request.get_json.return_value = {
+            'submission_uuid': '123-456-789',
+            'is_direct_archiving': True
+        }
+
+        mock_headers = {
+            'Api-Key': api_key
+        }
+        mock_request.headers = mock_headers
+
+        # when
+        response = self.app.post(
+            '/archiveSubmissions',
+            data=mock_request
+        ).json
+
+        # then
+        assert_that(response.get('error_status_code')).is_equal_to(request_timeout_status)
+        assert_that(response.get('message')).is_equal_to(archive_failed_message)
+        assert_that(response.get('detailed_error_message')).is_equal_to(error_message)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
dcp-557

Changes:
- Make direct archiver instantiation cleaner and use static factory methods.
- Use the updated BioStudies Client library and improve error reporting when parsing the error response from the archive.