### PR TITLE
[dcp-524] Add archive submitter for ENA study

### DIFF
--- a/archiver/direct.py
+++ b/archiver/direct.py
@@ -1,4 +1,5 @@
 import config
+from converter.ena.ena_study import EnaStudyConverter
 
 from hca.loader import HcaLoader, IngestApi
 from hca.submission import HcaSubmission
@@ -13,15 +14,18 @@ from submitter.biosamples_submitter_service import BioSamplesSubmitterService
 from submitter.biostudies import BioStudiesSubmitter
 from converter.biostudies import BioStudiesConverter
 from submitter.biostudies_submitter_service import BioStudiesSubmitterService
+from submitter.ena import Ena
+from submitter.ena_study import EnaSubmitter
 
 
 class DirectArchiver:
     def __init__(self, loader: HcaLoader, updater: HcaUpdater, biosamples_submitter: BioSamplesSubmitter = None,
-                 biostudies_submitter: BioStudiesSubmitter = None):
+                 biostudies_submitter: BioStudiesSubmitter = None, ena_submitter: EnaSubmitter = None):
         self.__loader = loader
         self.__updater = updater
         self.__biosamples_submitter = biosamples_submitter
         self.__biostudies_submitter = biostudies_submitter
+        self.__ena_submitter = ena_submitter
 
     def archive_project(self, project_uuid: str) -> HcaSubmission:
         hca_submission = self.__loader.get_project(project_uuid=project_uuid)
@@ -45,6 +49,9 @@ class DirectArchiver:
             if self.__check_accessions_existence(biosample_accessions, biostudies_accessions):
                 self.__exchange_sample_and_project_accessions(submission, biosample_accessions, biostudies_accessions[0])
 
+        if self.__ena_submitter:
+            self.__archive_ena_entities(ingest_entities_to_update, submission)
+
         for entity in ingest_entities_to_update:
             submission.add_accessions_to_attributes(entity)
             self.__updater.update_entity(entity)
@@ -55,14 +62,19 @@ class DirectArchiver:
                 biostudies_accession is not None
 
     def __archive_project_to_biostudies(self, ingest_entities_to_update, submission):
-        biostudies, accessions = self.__biostudies_submitter.send_all_projects(submission)
-        ingest_entities_to_update.extend(biostudies.get(CREATED_ENTITY, []))
+        biostudies_entities, accessions = self.__biostudies_submitter.send_all_projects(submission)
+        ingest_entities_to_update.extend(biostudies_entities.get(CREATED_ENTITY, []))
         return accessions
 
     def __archive_samples_to_biosamples(self, ingest_entities_to_update, submission):
-        biosamples, accessions = self.__biosamples_submitter.send_all_samples(submission)
-        ingest_entities_to_update.extend(biosamples.get(CREATED_ENTITY, []))
+        biosamples_entities, accessions = self.__biosamples_submitter.send_all_samples(submission)
+        ingest_entities_to_update.extend(biosamples_entities.get(CREATED_ENTITY, []))
         return accessions
+
+    def __archive_ena_entities(self, ingest_entities_to_update, submission):
+        ena_entities, ena_accessions = self.__ena_submitter.send_all_ena_entities(submission)
+        ingest_entities_to_update.extend(ena_entities.get(CREATED_ENTITY, []))
+        return ena_accessions
 
     def __exchange_sample_and_project_accessions(self, submission, biosample_accessions: list, biostudies_accession):
         self.__biostudies_submitter.update_submission_with_sample_accessions(biosample_accessions,
@@ -93,15 +105,21 @@ class DirectArchiver:
     def __create_biostudies_client(biostudies_password, biostudies_url, biostudies_username):
         return BioStudies(biostudies_url, biostudies_username, biostudies_password)
 
+    @staticmethod
+    def create_submitter_for_ena(ena_api_url, ena_api_username, ena_webin_password):
+        ena_client = Ena(ena_api_url, ena_api_username, ena_webin_password)
+        ena_study_converter = EnaStudyConverter()
+        return EnaSubmitter(ena_client, ena_study_converter)
+
 
 def direct_archiver_from_params(
         ingest_url: str,
         biosamples_url: str, biosamples_domain: str, aap_url: str, aap_user: str, aap_password: str,
-        biostudies_url: str, biostudies_username: str, biostudies_password: str
+        biostudies_url: str, biostudies_username: str, biostudies_password: str,
+        ena_api_url: str, ena_webin_username: str, ena_webin_password: str
 ) -> DirectArchiver:
     ingest_client = IngestApi(ingest_url)
     hca_loader = HcaLoader(ingest_client)
-
     hca_updater = HcaUpdater(ingest_client)
 
     biosamples_submitter = DirectArchiver.create_submitter_for_biosamples(aap_password, aap_url, aap_user,
@@ -110,9 +128,12 @@ def direct_archiver_from_params(
     biostudies_submitter = DirectArchiver.create_submitter_for_biostudies(biostudies_url, biostudies_username,
                                                                           biostudies_password)
 
+    ena_submitter = DirectArchiver.create_submitter_for_ena(ena_api_url, ena_webin_username, ena_webin_password)
+
     return DirectArchiver(loader=hca_loader, updater=hca_updater,
                           biosamples_submitter=biosamples_submitter,
-                          biostudies_submitter=biostudies_submitter)
+                          biostudies_submitter=biostudies_submitter,
+                          ena_submitter=ena_submitter)
 
 
 def direct_archiver_from_config() -> DirectArchiver:
@@ -125,6 +146,9 @@ def direct_archiver_from_config() -> DirectArchiver:
         'biosamples_domain': config.AAP_API_DOMAIN,
         'biostudies_url': config.BIOSTUDIES_URL,
         'biostudies_username': config.BIOSTUDIES_USERNAME,
-        'biostudies_password': config.BIOSTUDIES_PASSWORD
+        'biostudies_password': config.BIOSTUDIES_PASSWORD,
+        'ena_api_url': config.ENA_API_URL,
+        'ena_webin_username': config.ENA_WEBIN_USERNAME,
+        'ena_webin_password': config.ENA_WEBIN_PASSWORD
     }
     return direct_archiver_from_params(**params)

--- a/config.py
+++ b/config.py
@@ -51,3 +51,6 @@ BIOSTUDIES_URL = os.environ.get('BIOSTUDIES_API_URL', 'https://wwwdev.ebi.ac.uk/
 BIOSTUDIES_STUDY_URL = os.environ.get('BIOSTUDIES_STUDY_URL', 'https://wwwdev.ebi.ac.uk/biostudies/studies/')
 BIOSTUDIES_USERNAME = os.environ.get('BIOSTUDIES_API_USERNAME')
 BIOSTUDIES_PASSWORD = os.environ.get('BIOSTUDIES_API_PASSWORD')
+ENA_API_URL = os.environ.get('ENA_API_URL', 'https://wwwdev.ebi.ac.uk/ena/submit/drop-box/submit/')
+ENA_WEBIN_USERNAME = os.environ.get('ENA_WEBIN_USERNAME')
+ENA_WEBIN_PASSWORD = os.environ.get('ENA_WEBIN_PASSWORD')

--- a/converter/ena/base.py
+++ b/converter/ena/base.py
@@ -11,7 +11,7 @@ class BaseEnaConverter:
         self.ena_type = ena_type
         self.xml_spec = xml_spec
 
-    def convert(self, entity: dict, additional_attributes: dict = None) -> str:
+    def convert(self, entity: dict, additional_attributes: dict = {}):
         ena_set: Element = etree.XML(f'<{self.ena_type.upper()}_SET />')
         self._add_alias_to_additional_attributes(entity, additional_attributes)
         self.add_accession_and_alias(self.xml_spec, additional_attributes)
@@ -88,4 +88,4 @@ class BaseEnaConverter:
 
     @staticmethod
     def convert_to_xml_str(element: Element) -> str:
-        return etree.tostring(element, xml_declaration=True, pretty_print=True, encoding="UTF-8").decode("UTF-8")
+        return etree.tostring(element, xml_declaration=True, pretty_print=True, encoding="UTF-8")

--- a/submitter/biosamples.py
+++ b/submitter/biosamples.py
@@ -1,8 +1,8 @@
 from typing import Tuple, List
 
 from converter.biosamples import BioSamplesConverter
-from submission_broker.submission.submission import Submission, Entity
-from submission_broker.services.biosamples import BioSamples, AapClient
+from submission_broker.submission.submission import Submission
+from submission_broker.services.biosamples import BioSamples
 
 from submitter.base import Submitter
 from submitter.biosamples_submitter_service import BioSamplesSubmitterService

--- a/submitter/biostudies.py
+++ b/submitter/biostudies.py
@@ -1,7 +1,7 @@
 from typing import List, Tuple
 
 from submission_broker.services.biostudies import BioStudies
-from submission_broker.submission.submission import Submission, Entity
+from submission_broker.submission.submission import Submission
 
 from converter.biostudies import BioStudiesConverter
 from submitter.base import Submitter

--- a/submitter/ena.py
+++ b/submitter/ena.py
@@ -1,0 +1,43 @@
+from datetime import date
+from enum import Enum
+from http import HTTPStatus
+from typing import Dict, Tuple
+
+import requests
+from requests import Response
+from requests.auth import HTTPBasicAuth
+
+
+class EnaAction(Enum):
+    ADD = 'ADD'
+    MODIFY = 'MODIFY'
+
+
+class EnaError(Exception):
+    pass
+
+
+# TODO this class needs to go to the submission_broker library under the submission_broker.services package
+class Ena:
+
+    def __init__(self, ena_submission_url=None, username=None, password=None):
+        self.url = ena_submission_url
+        self.auth = HTTPBasicAuth(username, password)
+
+    def send_submission(self, ena_files: Dict[str, Tuple[str, str]], action: EnaAction = None, hold_date: str = None, center_name: str = None ):
+        data = {}
+        if action:
+            data['ACTION'] = action.value
+        if hold_date:
+            data['HOLD_DATE'] = hold_date
+        if center_name:
+            data['CENTER_NAME'] = center_name
+        response: Response = requests.post(self.url, auth=self.auth, data=data, files=ena_files)
+        if response.status_code == HTTPStatus(200):
+            return response.content
+        else:
+            message = f'ENA Responded with: HTTP{response.status_code}'
+            error = response.json()
+            if error:
+                raise EnaError(f"{message} {error['error']} {error['message']}")
+            raise EnaError(message)

--- a/submitter/ena_study.py
+++ b/submitter/ena_study.py
@@ -1,0 +1,41 @@
+from typing import List, Tuple
+from xml.etree import ElementTree
+from xml.etree.ElementTree import Element
+
+from submission_broker.submission.submission import Submission
+
+from converter.ena.ena_study import EnaStudyConverter
+from submitter.base import Submitter
+from submitter.ena import Ena, EnaAction
+
+ERROR_KEY = 'content.project_core.ena_study_accession'
+
+
+class EnaSubmitter(Submitter):
+    def __init__(self, archive_client: Ena, converter: EnaStudyConverter):
+        super().__init__(archive_client, converter)
+        self.__archive_client = archive_client
+        self.__converter = converter
+
+    def send_all_ena_entities(self, submission: Submission) -> Tuple[dict, List[str]]:
+        response, accessions = self.send_all_entities(submission, "ENA", ERROR_KEY)
+
+        return response, accessions
+
+    def _submit_to_archive(self, converted_entity):
+        # hardcoded for now, but it is going to change when we add more types to this dict
+        ena_files = {
+            'STUDY': ('STUDY.xml', converted_entity)
+        }
+
+        response = self.__archive_client.send_submission(
+            ena_files, EnaAction.ADD, self.release_date, 'HCA')
+
+        response_xml = ElementTree.fromstring(response.decode('utf-8'))
+
+        return {'accession': self.__get_accession(response_xml)}
+
+    @staticmethod
+    def __get_accession(response: Element):
+        for ena_entity in response.iter('STUDY'):
+            return ena_entity.attrib.get('accession')

--- a/tests/unit/converter/ena/test_ena_study_converter.py
+++ b/tests/unit/converter/ena/test_ena_study_converter.py
@@ -22,7 +22,7 @@ class EnaStudyConverterTest(unittest.TestCase):
         expected_payload = \
             self.__get_expected_payload('/../../../resources/expected_ena_study_payload_with_accession_and_alias.xml')
 
-        converted_payload = self.ena_study_converter.convert(self.project['attributes'], other_attributes)
+        converted_payload = self.ena_study_converter.convert(self.project['attributes'], other_attributes).decode("UTF-8")
 
         assert_that(converted_payload).is_equal_to(expected_payload)
 
@@ -32,7 +32,7 @@ class EnaStudyConverterTest(unittest.TestCase):
         expected_payload = \
             self.__get_expected_payload('/../../../resources/expected_ena_study_payload_with_only_alias.xml')
 
-        converted_payload = self.ena_study_converter.convert(self.project['attributes'], other_attributes)
+        converted_payload = self.ena_study_converter.convert(self.project['attributes'], other_attributes).decode("UTF-8")
 
         assert_that(converted_payload).is_equal_to(expected_payload)
 

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -10,7 +10,7 @@ def make_ingest_entity(ingest_type: str,
                        extra_links=None
                        ) -> dict:
     if not attributes:
-        attributes = {}
+        attributes = {'releaseDate': '2020-01-01T11:22:33Z'}
     if ingest_uuid:
         attributes['uuid'] = {'uuid': ingest_uuid}
     entity_uri = f'https://test_case.org/{ingest_type}/{ingest_index}'


### PR DESCRIPTION
dcp-524

Changes:
- Add submitter for sending ENA study metadata to ENA archive.