### PR TITLE
Index2 mapping added, default lane index 1.

### DIFF
--- a/ena/sequencing_run_converter.py
+++ b/ena/sequencing_run_converter.py
@@ -9,6 +9,7 @@ from archiver.archiver import Manifest
 # Add logic in checking the lib prep protocol
 READ_TYPES = {
     'index1': ['sample_barcode'],
+    'index2': ['sample_barcode'],
     'read1': [
         'cell_barcode',
         'umi_barcode'
@@ -108,7 +109,7 @@ class SequencingRunConverter:
     def _group_files_by_lane_index(self, files):
         lanes = {}
         for file in files:
-            lane_index = file.get('lane_index')
+            lane_index = file.get('lane_index', 1)
             if lane_index not in lanes:
                 lanes[lane_index] = []
             lanes[lane_index].append(file)

--- a/tests/unit/ena/test_sequencing_run_converter.py
+++ b/tests/unit/ena/test_sequencing_run_converter.py
@@ -9,6 +9,11 @@ from ena.sequencing_run_converter import SequencingRunConverter
 from ena.util import load_json, load_xml_dict, write_xml
 
 
+# for converting load_xml_dict output from xmltodict.parse to be unordered dict for assert comparisons
+def to_unordered_dict(ordered_dict: dict):
+    return json.loads(json.dumps(ordered_dict))
+
+
 class TestSequencingRunDataConverter(TestCase):
     def setUp(self) -> None:
         self.ingest_api = MagicMock()
@@ -152,7 +157,7 @@ class TestSequencingRunDataConverter(TestCase):
         expected_file = f'{self.expected_dir}/sample_add_run.xml'
         expected = load_xml_dict(expected_file)
 
-        self.assertEqual(json.loads(json.dumps(actual)), json.loads(json.dumps(expected)))
+        self.assertEqual(to_unordered_dict(actual), to_unordered_dict(expected))
 
     def test_convert_sequencing_run_data_to_xml_tree__multiple_runs(self):
         # given
@@ -170,8 +175,7 @@ class TestSequencingRunDataConverter(TestCase):
         expected_file = f'{self.expected_dir}/sample_add_multiple_runs.xml'
         expected = load_xml_dict(expected_file)
 
-        # convert load_xml_dict output from xmltodict.parse to be unordered dict for assert comparison
-        self.assertEqual(json.loads(json.dumps(actual)), json.loads(json.dumps(expected)))
+        self.assertEqual(to_unordered_dict(actual), to_unordered_dict(expected))
 
     def test_load_md5_file(self):
         # when
@@ -180,3 +184,4 @@ class TestSequencingRunDataConverter(TestCase):
         # then
         expected = load_json(f'{self.expected_dir}/md5.json')
         self.assertEqual(md5, expected)
+


### PR DESCRIPTION
For `ena/sequencing_run_converter.py`:
- Line 12: Added Index 2 to the read type mapping
- L111: Added a default lane index of 1. This is a workaround and we should work on improving the logic. For now, this should not pose any "danger" to the script, because datasets that lack the lane index **AND** need it (more than 1 set of fastq files per assay) will be caught by the graph validator before archiving