### PR TITLE
Use get to not raise exception when lane index from file metadata is missing

### DIFF
--- a/ena/sequencing_run_converter.py
+++ b/ena/sequencing_run_converter.py
@@ -132,7 +132,7 @@ class SequencingRunConverter:
 
         checksum = self._get_checksum(filename, md5)
         read_index = manifest_file['content']['read_index']
-        lane_index = manifest_file['content']['lane_index']
+        lane_index = manifest_file['content'].get('lane_index')
 
         file = {
             'url': manifest_file['_links']['self']['href'],


### PR DESCRIPTION
ebi-ait/hca-ebi-dev-team#464

1st part: it saves the lane index from metadata to a temp dict (this PR)
2nd part: it gets from that temp dict:  (PR defaulting to 1 lane index https://github.com/ebi-ait/ingest-archiver/pull/62 )