### PR TITLE
[dcp-581] Fix some issues with archiving

### DIFF
--- a/archiver_app.py
+++ b/archiver_app.py
@@ -84,15 +84,14 @@ def archive():
     if is_direct_archiving:
         try:
             direct_archiver = direct_archiver_from_config()
-            submission = direct_archiver.archive_submission(submission_uuid)
-            response = submission.as_dict(string_lists=True)
+            response = direct_archiver.archive_submission(submission_uuid)
             logger.info('Archiving finished with UUID=%s', submission_uuid)
-        except RestErrorException as e:
-            log_error_message(e, submission_uuid)
+        except RestErrorException as rest_error:
+            log_error_message(rest_error, submission_uuid)
             response = {
                 'message': 'Archiving failed.',
-                'detailed_error_message': e.message,
-                'error_status_code': e.status_code
+                'detailed_error_message': rest_error.message,
+                'error_status_code': rest_error.status_code
             }
     else:
         ingest_api = IngestAPI(config.INGEST_API_URL)

--- a/converter/biostudies.py
+++ b/converter/biostudies.py
@@ -77,10 +77,6 @@ class BioStudiesConverter:
             {
                 'name': ['', default_to, 'HCA Project UUID'],
                 'value': ['uuid.uuid']
-            },
-            {
-                'name': ['', default_to, 'ReleaseDate'],
-                'value': ['releaseDate']
             }
         ]
         self.project_spec_section = {
@@ -101,19 +97,29 @@ class BioStudiesConverter:
         }
 
     def convert(self, hca_project: dict, additional_attributes: dict = None) -> dict:
-        if hca_project.get('releaseDate') is None:
-            self.__set_release_date(hca_project)
-
         converted_project = JsonMapper(hca_project).map({
             'attributes': ['$array', self.project_spec_base, True],
             'section': self.project_spec_section
             })
+
+        self.add_release_date(converted_project, hca_project)
 
         project_content = hca_project['content'] if 'content' in hca_project else None
         if project_content:
             self.__add_subsections_to_project(converted_project, project_content)
 
         return converted_project
+
+    @staticmethod
+    def add_release_date(converted_project, hca_project):
+        release_date = hca_project.get('releaseDate')
+        if release_date:
+            converted_project.get('attributes').append(
+                {
+                    'name': 'ReleaseDate',
+                    'value': release_date
+                }
+            )
 
     @staticmethod
     def __set_release_date(hca_project: dict):

--- a/converter/biostudies.py
+++ b/converter/biostudies.py
@@ -1,4 +1,5 @@
 import copy
+from datetime import datetime
 
 from json_converter.json_mapper import JsonMapper
 from json_converter.post_process import default_to
@@ -100,6 +101,9 @@ class BioStudiesConverter:
         }
 
     def convert(self, hca_project: dict, additional_attributes: dict = None) -> dict:
+        if hca_project.get('releaseDate') is None:
+            self.__set_release_date(hca_project)
+
         converted_project = JsonMapper(hca_project).map({
             'attributes': ['$array', self.project_spec_base, True],
             'section': self.project_spec_section
@@ -110,6 +114,10 @@ class BioStudiesConverter:
             self.__add_subsections_to_project(converted_project, project_content)
 
         return converted_project
+
+    @staticmethod
+    def __set_release_date(hca_project: dict):
+        hca_project.update({'releaseDate': datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")})
 
     def __add_subsections_to_project(self, converted_project, project_content):
         contributors = project_content.get('contributors')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ assertpy~=1.1
 biosamples_client~=1.3.0
 biostudies-client~=0.1.5
 xmltodict~=0.12.0
-submission_broker~=0.1.2
+submission_broker~=0.2.0
 polling==0.3.1
 flatten_json~=0.1.13
 json_converter~=0.5.0

--- a/tests/resources/expected_biostudies_payload_without_release_date.json
+++ b/tests/resources/expected_biostudies_payload_without_release_date.json
@@ -1,0 +1,185 @@
+{
+  "attributes": [
+    {
+      "name": "Project Core - Project Short Name",
+      "value": "Adult_Nonmobilised_PB"
+    },
+    {
+      "name": "HCA Project UUID",
+      "value": "fc55bd4a-8694-4a28-9a35-59a685bda323"
+    }
+  ],
+  "section": {
+    "accno": "PROJECT",
+    "type": "Study",
+    "attributes": [
+      {
+        "name": "Title",
+        "value": "Transcriptomic characterisation of haematopoietic stem and progenitor cells from adult human homeostatic (non-mobilised) peripheral blood"
+      },
+      {
+        "name": "Description",
+        "value": "Haematopoietic stem and progenitor cells (HSPCs), the precursors of all blood cells, reside predominantly in the bone marrow. Yet, a  small proportion (<1%) of phenotypic HSPCs circulates through peripheral blood (PB) at any given time. To date, the detailed characterization of steady-state circulating HSPCs in adult humans remains very poor. Here, we analyse the single-cell composition of the adult human HSPC pool within non-mobilised PB from four healthy donors. 10x scRNA-seq of 22000 HSPCs from all four donors was paired with single-cell functional analysis using most immature haematopoietic stem cells and multipotent progenitors (HSC/MPPs). We find that long-term functional HSC/MPPs are very rare in non-mobilised PB, and that a large fraction of circulating HSPCs is biased towards the erythroid lineage. In particular, we detect the enrichment of a subset of exclusively erythroid/megakaryocyte-primed quiescent HSC-like cells within the phenotypic PB HSC/MPP compartment."
+      }
+    ],
+    "subsections": [
+      {
+        "type": "Publication",
+        "attributes": [
+          {
+            "name": "Authors",
+            "value": "Stephenson E, Reynolds G, Botting RA, Calero-Nieto FJ, Morgan M, Tuong ZK, Bach K, Sungnak W, Worlock KB, Yoshida M, Kumasaka N, Kania K, Engelbert J, Olabi B, Spegarova JS, Wilson NK, Mende N, Jardine L, Gardner LC, Goh I, Horsfall D, McGrath J, Webb S, Mather MW, Lindeboom RG, Dann E, Huang N, Polanski K, Prigmore E, Gothe F, Scott J, Payne RP, Baker KF, Hanrath AT, Schim van der Loeff IC, Barr AS, Sanchez-Gonzalez A, Bergamaschi L, Mescia F, Barnes JL, Kilich E, Wilton Ad, Saigal A, Saleh A, Janes SM, Smith CM, Gopee N, Wilson C, Coupland P, Coxhead JM, Kiselev VY, Dongen Sv, Bacardit J, King HW, Rostron AJ, Simpson AJ, Hambleton S, Laurenti E, Lyons PA, Meyer KB, Nikolic MZ, Duncan CJ, Smith K, Teichmann SA, Clatworthy MR, Marioni JC, Gottgens B, Haniffa M, "
+          },
+          {
+            "name": "Title",
+            "value": "Single-cell multi-omics analysis of the immune response in COVID-19"
+          },
+          {
+            "name": "doi",
+            "value": "10.1038/s41591-021-01329-2"
+          },
+          {
+            "name": "URL",
+            "value": "https://www.nature.com/articles/s41591-021-01329-2#Sec8"
+          }
+        ]
+      },
+      {
+        "type": "Author",
+        "accno": "a1",
+        "attributes": [
+          {
+            "name": "Name",
+            "value": "Elisa,Doe,Laurenti"
+          },
+          {
+            "name": "First Name",
+            "value": "Elisa"
+          },
+          {
+            "name": "Middle Initials",
+            "value": "D"
+          },
+          {
+            "name": "Last Name",
+            "value": "Laurenti"
+          },
+          {
+            "name": "Email",
+            "value": "el422@cam.ac.uk"
+          },
+          {
+            "name": "Phone",
+            "value": "+44 (0) 1223 762044"
+          },
+          {
+            "name": "Address",
+            "value": "Jeffrey Cheah Biomedical Centre,\nPuddicombe Way, CB2 0AW, Cambridge"
+          },
+          {
+            "name": "Orcid ID",
+            "value": "0000-0001-0002-0003"
+          },
+          {
+            "name": "affiliation",
+            "reference": true,
+            "value": "o1"
+          }
+        ]
+      },
+      {
+        "type": "Author",
+        "accno": "a2",
+        "attributes": [
+          {
+            "name": "Name",
+            "value": "Ami,,Day"
+          },
+          {
+            "name": "First Name",
+            "value": "Ami"
+          },
+          {
+            "name": "Last Name",
+            "value": "Day"
+          },
+          {
+            "name": "Email",
+            "value": "ami@ebi.ac.uk"
+          },
+          {
+            "name": "Phone",
+            "value": "345678"
+          },
+          {
+            "name": "Address",
+            "value": "Wellcome Genome Campus, Cambridge, CB10 1SD"
+          },
+          {
+            "name": "Orcid ID",
+            "value": "0004-0005-006-0007"
+          },
+          {
+            "name": "affiliation",
+            "reference": true,
+            "value": "o2"
+          }
+        ]
+      },
+      {
+        "accno": "o1",
+        "attributes": [
+          {
+            "name": "Name",
+            "value": "Wellcome - MRC Cambridge Stem Cell Institute"
+          }
+        ],
+        "type": "Organization"
+      },
+      {
+        "accno": "o2",
+        "attributes": [
+          {
+            "name": "Name",
+            "value": "EMBL-EBI"
+          }
+        ],
+        "type": "Organization"
+      },
+      {
+        "type": "Funding",
+        "attributes": [
+          {
+            "name": "grant_id",
+            "value": "BB/P002293/1"
+          },
+          {
+            "name": "Grant Title",
+            "value": "Cellular and molecular dynamics of healthy ageing in the human Haematopoietic Stem Cell Compartment"
+          },
+          {
+            "name": "Agency",
+            "value": "Biotechnology and Biological Sciences Research Council (BBSRC)"
+          }
+        ]
+      },
+      {
+        "type": "Funding",
+        "attributes": [
+          {
+            "name": "grant_id",
+            "value": "107630/Z/15/Z"
+          },
+          {
+            "name": "Grant Title",
+            "value": "Characterization of inflammation driven responses in human haematopoietic stem and progenitor cells"
+          },
+          {
+            "name": "Agency",
+            "value": "Wellcome Trust"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/unit/converter/test_biostudies_converter.py
+++ b/tests/unit/converter/test_biostudies_converter.py
@@ -24,6 +24,19 @@ class TestBioStudiesConverter(unittest.TestCase):
         self.assertEqual(json.dumps(expected_payload, sort_keys=True, indent=2),
                          json.dumps(converted_payload, sort_keys=True, indent=2))
 
+    def test_given_ingest_project_converts_correct_biostudies_payload(self):
+        self.maxDiff = None
+        attributes = self.project.get('attributes')
+        attributes.update({'releaseDate': None})
+
+        expected_payload = \
+            self.__get_expected_payload('/../../resources/expected_biostudies_payload_without_release_date.json')
+
+        converted_payload = self.biostudies_converter.convert(self.project['attributes'])
+
+        self.assertEqual(json.dumps(expected_payload, sort_keys=True, indent=2),
+                         json.dumps(converted_payload, sort_keys=True, indent=2))
+
     def test_given_ingest_project_converts_project_twice_should_return_correct_biostudies_payload(self):
         self.maxDiff = None
         expected_payload = self.__get_expected_payload('/../../resources/expected_biostudies_payload.json')


### PR DESCRIPTION
Changes:

- Make code cleaner
- Set the release date of the project to current date if it is not given by user
- send Biostudies accession as a string instead of an array

I would like to deploy this to dev to be able to test my archiving script. I tested that script locally and it worked fine.
If it works successfully with DEV environment, then I am creating a PR for that one too.