### PR TITLE
[dcp-824] Use biomaterial_id if biomaterial_name is not present

### DIFF
--- a/converter/biosamples.py
+++ b/converter/biosamples.py
@@ -35,8 +35,8 @@ class BioSamplesConverter:
             accession=attributes.get('accession', core.get('biosamples_accession')),
             name=name,
             domain=domain,
-            species=content['genus_species'][0].get('ontology_label') if len(content.get('genus_species', [])) else None,
-            ncbi_taxon_id=core.get('ncbi_taxon_id')[0] if len(core.get('ncbi_taxon_id', [])) else None,
+            species=content['genus_species'][0].get('ontology_label') if content.get('genus_species', []) else None,
+            ncbi_taxon_id=core.get('ncbi_taxon_id')[0] if core.get('ncbi_taxon_id', []) else None,
             update=self.__datetime(biomaterial.get('updateDate')),
             release=self.__datetime(attributes.get('release_date', biomaterial.get('submissionDate')))
         )

--- a/converter/biosamples.py
+++ b/converter/biosamples.py
@@ -27,15 +27,13 @@ class BioSamplesConverter:
         if not domain:
             raise MissingBioSamplesDomain()
         release_date = attributes.get('release_date')
-        existing_accession = attributes.get('accession')
         content = biomaterial.get('content', {})
         core = content.get('biomaterial_core', {})
-        accession = self.__define_accession(existing_accession, core)
         name = core.get('biomaterial_name', core.get('biomaterial_id'))
         if not name:
             raise MissingBioSamplesSampleName()
         sample = Sample(
-            accession=accession,
+            accession=attributes.get('accession', core.get('biosamples_accession')),
             name=name,
             domain=domain,
             species=content['genus_species'][0].get('ontology_label') if content.get(
@@ -47,16 +45,6 @@ class BioSamplesConverter:
         sample._append_organism_attribute()
         self.__add_attributes(sample, biomaterial)
         return sample
-
-    @staticmethod
-    def __define_accession(existing_accession: str, biomaterial_core):
-        accession = existing_accession if existing_accession and len(existing_accession) > 0 \
-            else biomaterial_core.get('biosamples_accession')
-
-        if accession and len(accession) > 0:
-            return accession
-        else:
-            return None
 
     @staticmethod
     def __add_attributes(sample: Sample, biomaterial: dict):

--- a/converter/biosamples.py
+++ b/converter/biosamples.py
@@ -26,7 +26,6 @@ class BioSamplesConverter:
         domain = attributes.get('domain', self.default_domain)
         if not domain:
             raise MissingBioSamplesDomain()
-        release_date = attributes.get('release_date')
         content = biomaterial.get('content', {})
         core = content.get('biomaterial_core', {})
         name = core.get('biomaterial_name', core.get('biomaterial_id'))
@@ -40,7 +39,7 @@ class BioSamplesConverter:
                 'genus_species') else None,
             ncbi_taxon_id=core.get('ncbi_taxon_id')[0] if core.get('ncbi_taxon_id') else None,
             update=self.__datetime(biomaterial.get('updateDate')),
-            release=self.__datetime(release_date if release_date else biomaterial.get('submissionDate'))
+            release=self.__datetime(attributes.get('release_date', biomaterial.get('submissionDate')))
         )
         sample._append_organism_attribute()
         self.__add_attributes(sample, biomaterial)

--- a/converter/biosamples.py
+++ b/converter/biosamples.py
@@ -4,7 +4,7 @@ from biosamples_v4.models import Sample, Attribute
 from json_converter.json_mapper import JsonMapper
 
 from . import get_concrete_type
-from .errors import MissingBioSamplesDomain
+from .errors import MissingBioSamplesDomain, MissingBioSamplesSampleName
 
 ATTRIBUTE_SPEC = {
     'Biomaterial Core - Biomaterial Id': ['content.biomaterial_core.biomaterial_id'],
@@ -31,11 +31,12 @@ class BioSamplesConverter:
         biomaterial_content = biomaterial.get('content', {})
         biomaterial_core = biomaterial_content.get('biomaterial_core', {})
         sample_accession = self.__define_accession(existing_accession, biomaterial_core)
-        biomaterial_name = biomaterial_core.get('biomaterial_name') if biomaterial_core.get('biomaterial_name') \
-            else biomaterial_core.get('biomaterial_id', '')
+        name = biomaterial_core.get('biomaterial_name', biomaterial_core.get('biomaterial_id'))
+        if not name:
+            raise MissingBioSamplesSampleName()
         sample = Sample(
             accession=sample_accession,
-            name=biomaterial_name,
+            name=name,
             domain=domain,
             species=biomaterial_content['genus_species'][0].get('ontology_label') if biomaterial_content.get(
                 'genus_species') else None,

--- a/converter/biosamples.py
+++ b/converter/biosamples.py
@@ -21,12 +21,13 @@ class BioSamplesConverter:
         self.default_domain = default_domain
 
     def convert(self, biomaterial: dict, additional_attributes: dict = None) -> Sample:
-        domain = additional_attributes.get('domain')
+        if not additional_attributes:
+            additional_attributes = {}
+        domain = additional_attributes.get('domain', self.default_domain)
+        if not domain:
+            raise MissingBioSamplesDomain()
         release_date = additional_attributes.get('release_date')
         existing_accession = additional_attributes.get('accession')
-
-        if not domain and not self.default_domain:
-            raise MissingBioSamplesDomain()
         biomaterial_content = biomaterial.get('content', {})
         biomaterial_core = biomaterial_content.get('biomaterial_core', {})
         sample_accession = self.__define_accession(existing_accession, biomaterial_core)
@@ -35,7 +36,7 @@ class BioSamplesConverter:
         sample = Sample(
             accession=sample_accession,
             name=biomaterial_name,
-            domain=domain if domain else self.default_domain,
+            domain=domain,
             species=biomaterial_content['genus_species'][0].get('ontology_label') if biomaterial_content.get(
                 'genus_species') else None,
             ncbi_taxon_id=biomaterial_core.get('ncbi_taxon_id')[0] if biomaterial_core.get('ncbi_taxon_id') else None,

--- a/converter/biosamples.py
+++ b/converter/biosamples.py
@@ -6,7 +6,6 @@ from json_converter.json_mapper import JsonMapper
 from . import get_concrete_type
 from .errors import MissingBioSamplesDomain
 
-
 ATTRIBUTE_SPEC = {
     'Biomaterial Core - Biomaterial Id': ['content.biomaterial_core.biomaterial_id'],
     'HCA Biomaterial Type': ['content.describedBy', get_concrete_type],
@@ -31,11 +30,14 @@ class BioSamplesConverter:
         biomaterial_content = biomaterial.get('content', {})
         biomaterial_core = biomaterial_content.get('biomaterial_core', {})
         sample_accession = self.__define_accession(existing_accession, biomaterial_core)
+        biomaterial_name = biomaterial_core.get('biomaterial_name') if biomaterial_core.get('biomaterial_name') \
+            else biomaterial_core.get('biomaterial_id', '')
         sample = Sample(
             accession=sample_accession,
-            name=biomaterial_core.get('biomaterial_name'),
+            name=biomaterial_name,
             domain=domain if domain else self.default_domain,
-            species=biomaterial_content['genus_species'][0].get('ontology_label') if biomaterial_content.get('genus_species') else None,
+            species=biomaterial_content['genus_species'][0].get('ontology_label') if biomaterial_content.get(
+                'genus_species') else None,
             ncbi_taxon_id=biomaterial_core.get('ncbi_taxon_id')[0] if biomaterial_core.get('ncbi_taxon_id') else None,
             update=self.__convert_datetime(biomaterial.get('updateDate')),
             release=self.__convert_datetime(release_date if release_date else biomaterial.get('submissionDate'))
@@ -46,14 +48,13 @@ class BioSamplesConverter:
 
     @staticmethod
     def __define_accession(existing_accession: str, biomaterial_core):
-        accession = existing_accession if existing_accession and len(existing_accession) > 0\
+        accession = existing_accession if existing_accession and len(existing_accession) > 0 \
             else biomaterial_core.get('biosamples_accession')
 
         if accession and len(accession) > 0:
             return accession
         else:
             return None
-
 
     @staticmethod
     def __add_attributes(sample: Sample, biomaterial: dict):

--- a/converter/biosamples.py
+++ b/converter/biosamples.py
@@ -35,9 +35,8 @@ class BioSamplesConverter:
             accession=attributes.get('accession', core.get('biosamples_accession')),
             name=name,
             domain=domain,
-            species=content['genus_species'][0].get('ontology_label') if content.get(
-                'genus_species') else None,
-            ncbi_taxon_id=core.get('ncbi_taxon_id')[0] if core.get('ncbi_taxon_id') else None,
+            species=content['genus_species'][0].get('ontology_label') if len(content.get('genus_species', [])) else None,
+            ncbi_taxon_id=core.get('ncbi_taxon_id')[0] if len(core.get('ncbi_taxon_id', [])) else None,
             update=self.__datetime(biomaterial.get('updateDate')),
             release=self.__datetime(attributes.get('release_date', biomaterial.get('submissionDate')))
         )

--- a/converter/biosamples.py
+++ b/converter/biosamples.py
@@ -20,29 +20,29 @@ class BioSamplesConverter:
     def __init__(self, default_domain=None):
         self.default_domain = default_domain
 
-    def convert(self, biomaterial: dict, additional_attributes: dict = None) -> Sample:
-        if not additional_attributes:
-            additional_attributes = {}
-        domain = additional_attributes.get('domain', self.default_domain)
+    def convert(self, biomaterial: dict, attributes: dict = None) -> Sample:
+        if not attributes:
+            attributes = {}
+        domain = attributes.get('domain', self.default_domain)
         if not domain:
             raise MissingBioSamplesDomain()
-        release_date = additional_attributes.get('release_date')
-        existing_accession = additional_attributes.get('accession')
-        biomaterial_content = biomaterial.get('content', {})
-        biomaterial_core = biomaterial_content.get('biomaterial_core', {})
-        sample_accession = self.__define_accession(existing_accession, biomaterial_core)
-        name = biomaterial_core.get('biomaterial_name', biomaterial_core.get('biomaterial_id'))
+        release_date = attributes.get('release_date')
+        existing_accession = attributes.get('accession')
+        content = biomaterial.get('content', {})
+        core = content.get('biomaterial_core', {})
+        accession = self.__define_accession(existing_accession, core)
+        name = core.get('biomaterial_name', core.get('biomaterial_id'))
         if not name:
             raise MissingBioSamplesSampleName()
         sample = Sample(
-            accession=sample_accession,
+            accession=accession,
             name=name,
             domain=domain,
-            species=biomaterial_content['genus_species'][0].get('ontology_label') if biomaterial_content.get(
+            species=content['genus_species'][0].get('ontology_label') if content.get(
                 'genus_species') else None,
-            ncbi_taxon_id=biomaterial_core.get('ncbi_taxon_id')[0] if biomaterial_core.get('ncbi_taxon_id') else None,
-            update=self.__convert_datetime(biomaterial.get('updateDate')),
-            release=self.__convert_datetime(release_date if release_date else biomaterial.get('submissionDate'))
+            ncbi_taxon_id=core.get('ncbi_taxon_id')[0] if core.get('ncbi_taxon_id') else None,
+            update=self.__datetime(biomaterial.get('updateDate')),
+            release=self.__datetime(release_date if release_date else biomaterial.get('submissionDate'))
         )
         sample._append_organism_attribute()
         self.__add_attributes(sample, biomaterial)
@@ -81,7 +81,7 @@ class BioSamplesConverter:
             sample.external_references.extend(biomaterial.get('externalReferences'))
 
     @staticmethod
-    def __convert_datetime(datetime_str: str) -> datetime:
+    def __datetime(datetime_str: str) -> datetime:
         if datetime_str:
             if '.' in datetime_str:
                 datetime_format = '%Y-%m-%dT%H:%M:%S.%fZ'

--- a/converter/errors.py
+++ b/converter/errors.py
@@ -9,3 +9,8 @@ class BioSamplesConversionError(ConversionError):
 class MissingBioSamplesDomain(BioSamplesConversionError):
     def __init__(self):
         self.message = 'A BioSamples domain must be specified.'
+
+
+class MissingBioSamplesSampleName(BioSamplesConversionError):
+    def __init__(self):
+        self.message = 'A BioSamples sample must specify a name.'

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ json_converter~=0.5.0
 Flask~=1.1.2
 requests~=2.25.1
 urllib3~=1.25.11
-mock~=4.0.3
 -e git+https://github.com/ebi-ait/ingest-client.git@7fd3c25#egg=hca_ingest
 lxml~=4.6.3
 colorlog~=6.6.0

--- a/tests/unit/converter/test_biosamples_converter.py
+++ b/tests/unit/converter/test_biosamples_converter.py
@@ -77,9 +77,9 @@ class BioSamplesConverterTests(unittest.TestCase):
             # when
             self.biosamples_converter.convert(biomaterial)
 
-    def test_sample_uses_attribute_accession(self):
+    def test_sample_uses_attribute_accession_with_no_core_accession(self):
         # given
-        biomaterial = self.__get_biomaterial_by_id('accession-attribute-no-content-test')
+        biomaterial = self.__get_biomaterial_by_id('accession-from-attribute-without-core-accession')
         target_biosample = self.__create_a_sample()
         # when
         additional_attributes = {
@@ -89,9 +89,9 @@ class BioSamplesConverterTests(unittest.TestCase):
         # then
         self.assertEqual(SampleMatcher(target_biosample), converted_biosample)
 
-    def test_sample_uses_attribute_accession_over_core_accession(self):
+    def test_sample_uses_attribute_accession_instead_of_core_accession(self):
         # given
-        biomaterial = self.__get_biomaterial_by_id('accession-attribute-override-test')
+        biomaterial = self.__get_biomaterial_by_id('accession-from-attribute-with-core-accession')
         target_biosample = self.__create_a_sample()
         # when
         additional_attributes = {
@@ -103,7 +103,7 @@ class BioSamplesConverterTests(unittest.TestCase):
 
     def test_sample_uses_core_accession_if_no_attribute_accession(self):
         # given
-        biomaterial = self.__get_biomaterial_by_id('accession-content-test')
+        biomaterial = self.__get_biomaterial_by_id('accession-from-core-without-attribute')
         target_biosample = self.__create_a_sample()
         # when
         converted_biosample = self.biosamples_converter.convert(biomaterial)

--- a/tests/unit/converter/test_biosamples_converter.py
+++ b/tests/unit/converter/test_biosamples_converter.py
@@ -28,7 +28,9 @@ class BioSamplesConverterTests(unittest.TestCase):
             'domain': self.domain
         }
 
-        biosample = self.__create_a_sample(release_date)
+        sample_name = 'Bone Marrow CD34+ stem/progenitor cells'
+        biomaterial_id = 'HS_BM_2_cell_line'
+        biosample = self.__create_a_sample(release_date, biomaterial_id, sample_name)
 
         converted_bio_sample = self.biosamples_converter.convert(biomaterial, additional_attributes)
 
@@ -43,16 +45,34 @@ class BioSamplesConverterTests(unittest.TestCase):
             'domain': self.domain
         }
 
-        biosample = self.__create_a_sample(submission_date)
+        sample_name = 'Bone Marrow CD34+ stem/progenitor cells'
+        biomaterial_id = 'HS_BM_2_cell_line'
+        biosample = self.__create_a_sample(submission_date, biomaterial_id, sample_name)
 
         converted_bio_sample = self.biosamples_converter.convert(biomaterial, additional_attributes )
 
         self.assertEqual(SampleMatcher(biosample), converted_bio_sample)
 
-    def __create_a_sample(self, release_date):
+    def test_when_biomaterial_has_no_name_converted_biosample_has_biomaterial_id_as_name(self):
+        biomaterial = self.__get_biomaterial_by_index(1)
+
+        submission_date = '2019-07-18T21:12:39.770Z'
+        sample_name = 'BP37d'
+        biomaterial_id = 'BP37d'
+        biosample = self.__create_a_sample(submission_date, biomaterial_id, sample_name)
+
+        additional_attributes = {
+            'domain': self.domain
+        }
+
+        converted_bio_sample = self.biosamples_converter.convert(biomaterial, additional_attributes)
+
+        self.assertEqual(SampleMatcher(biosample), converted_bio_sample)
+
+    def __create_a_sample(self, release_date, biomaterial_id, sample_name):
         biosample = Sample(
             accession='SAMEA6877932',
-            name='Bone Marrow CD34+ stem/progenitor cells',
+            name=sample_name,
             release=datetime.strptime(release_date, '%Y-%m-%dT%H:%M:%S.%fZ'),
             update=datetime(2020, 6, 12, 14, 26, 37, 998000),
             domain=self.domain,
@@ -62,7 +82,7 @@ class BioSamplesConverterTests(unittest.TestCase):
         biosample._append_organism_attribute()
         self.__create_attributes(biosample,
                                  {
-                                     'Biomaterial Core - Biomaterial Id': 'HS_BM_2_cell_line',
+                                     'Biomaterial Core - Biomaterial Id': biomaterial_id,
                                      'HCA Biomaterial Type': 'cell_line',
                                      'HCA Biomaterial UUID': '501ba65c-0b04-430d-9aad-917935ee3c3c',
                                      'Is Living': 'yes',

--- a/tests/unit/converter/test_biosamples_converter.py
+++ b/tests/unit/converter/test_biosamples_converter.py
@@ -138,7 +138,7 @@ class BioSamplesConverterTests(unittest.TestCase):
 
     def test_sample_species_from_biomaterial_when_genus_species_no_ontology(self):
         # given
-        biomaterial = self.__get_biomaterial_by_id('genus-no-ontology')
+        biomaterial = self.__get_biomaterial_by_id('genus-no-ontology-label')
         target_biosample = self.__create_a_sample(species=None)
         # when
         converted_biosample = self.biosamples_converter.convert(biomaterial)

--- a/tests/unit/converter/test_biosamples_converter.py
+++ b/tests/unit/converter/test_biosamples_converter.py
@@ -7,6 +7,7 @@ from typing import List
 from biosamples_v4.models import Sample, Attribute
 
 from converter.biosamples import BioSamplesConverter
+from converter.errors import MissingBioSamplesDomain, MissingBioSamplesSampleName
 
 
 class BioSamplesConverterTests(unittest.TestCase):
@@ -14,88 +15,192 @@ class BioSamplesConverterTests(unittest.TestCase):
     def setUp(self) -> None:
         with open(dirname(__file__) + '/../resources/biomaterials.json') as file:
             self.biomaterials = json.load(file)
-
-        self.biosamples_converter = BioSamplesConverter()
         self.domain = 'self.test_domain'
+        self.biosamples_converter = BioSamplesConverter(self.domain)
 
     def test_given_ingest_biomaterial_when_release_date_defined_in_project_converts_correct_biosample(
             self):
+        # given
         biomaterial = self.__get_biomaterial_by_index(0)
-
         release_date = '2020-08-01T14:26:37.998Z'
+        biosample = self.__create_a_sample(release_date=release_date)
+        # when
         additional_attributes = {
             'release_date': str(release_date),
-            'domain': self.domain
         }
-
-        sample_name = 'Bone Marrow CD34+ stem/progenitor cells'
-        biomaterial_id = 'HS_BM_2_cell_line'
-        biosample = self.__create_a_sample(release_date, biomaterial_id, sample_name)
-
         converted_bio_sample = self.biosamples_converter.convert(biomaterial, additional_attributes)
-
+        # then
         self.assertEqual(SampleMatcher(biosample), converted_bio_sample)
 
     def test_given_ingest_biomaterial_when_release_date_not_defined_in_project_converts_correct_biosample(
             self):
+        # given
         biomaterial = self.__get_biomaterial_by_index(0)
-
-        submission_date = '2019-07-18T21:12:39.770Z'
-        additional_attributes = {
-            'domain': self.domain
-        }
-
-        sample_name = 'Bone Marrow CD34+ stem/progenitor cells'
-        biomaterial_id = 'HS_BM_2_cell_line'
-        biosample = self.__create_a_sample(submission_date, biomaterial_id, sample_name)
-
-        converted_bio_sample = self.biosamples_converter.convert(biomaterial, additional_attributes )
-
+        biosample = self.__create_a_sample()
+        # when
+        converted_bio_sample = self.biosamples_converter.convert(biomaterial)
+        # then
         self.assertEqual(SampleMatcher(biosample), converted_bio_sample)
 
     def test_when_biomaterial_has_no_name_converted_biosample_has_biomaterial_id_as_name(self):
+        # given
         biomaterial = self.__get_biomaterial_by_index(1)
-
-        submission_date = '2019-07-18T21:12:39.770Z'
-        sample_name = 'BP37d'
-        biomaterial_id = 'BP37d'
-        biosample = self.__create_a_sample(submission_date, biomaterial_id, sample_name)
-
-        additional_attributes = {
-            'domain': self.domain
-        }
-
-        converted_bio_sample = self.biosamples_converter.convert(biomaterial, additional_attributes)
-
+        biosample = self.__create_a_sample(biomaterial_id='BP37d', name='BP37d')
+        # when
+        converted_bio_sample = self.biosamples_converter.convert(biomaterial)
+        # then
         self.assertEqual(SampleMatcher(biosample), converted_bio_sample)
 
-    def __create_a_sample(self, release_date, biomaterial_id, sample_name):
-        biosample = Sample(
+    def test_sample_can_convert_sample_with_no_attributes(self):
+        # given
+        biomaterial = self.__get_biomaterial_by_index(0)
+        target_biosample = self.__create_a_sample()
+        # when
+        converted_biosample = self.biosamples_converter.convert(biomaterial)
+        # then
+        self.assertEqual(SampleMatcher(target_biosample), converted_biosample)
+
+    def test_sample_throws_error_with_no_domain(self):
+        # given
+        self.biosamples_converter = BioSamplesConverter()
+        biomaterial = {}
+        # then
+        with self.assertRaises(MissingBioSamplesDomain):
+            # when
+            self.biosamples_converter.convert(biomaterial)
+
+    def test_sample_throws_error_with_no_name(self):
+        # given
+        biomaterial = {}
+        # then
+        with self.assertRaises(MissingBioSamplesSampleName):
+            # when
+            self.biosamples_converter.convert(biomaterial)
+
+    def test_sample_uses_attribute_accession(self):
+        # given
+        biomaterial = self.__get_biomaterial_by_id('accession-attribute-no-content-test')
+        target_biosample = self.__create_a_sample()
+        # when
+        additional_attributes = {
+            'accession': biomaterial.get('accession')
+        }
+        converted_biosample = self.biosamples_converter.convert(biomaterial, additional_attributes)
+        # then
+        self.assertEqual(SampleMatcher(target_biosample), converted_biosample)
+
+    def test_sample_uses_attribute_accession_over_core_accession(self):
+        # given
+        biomaterial = self.__get_biomaterial_by_id('accession-attribute-override-test')
+        target_biosample = self.__create_a_sample()
+        # when
+        additional_attributes = {
+            'accession': biomaterial.get('accession')
+        }
+        converted_biosample = self.biosamples_converter.convert(biomaterial, additional_attributes)
+        # then
+        self.assertEqual(SampleMatcher(target_biosample), converted_biosample)
+
+    def test_sample_uses_core_accession_if_no_attribute_accession(self):
+        # given
+        biomaterial = self.__get_biomaterial_by_id('accession-content-test')
+        target_biosample = self.__create_a_sample()
+        # when
+        converted_biosample = self.biosamples_converter.convert(biomaterial)
+        # then
+        self.assertEqual(SampleMatcher(target_biosample), converted_biosample)
+
+    def test_sample_does_not_need_an_accession(self):
+        biomaterial = self.__get_biomaterial_by_id('accession-missing-test')
+        target_biosample = self.__create_a_sample(accession=None)
+        # when
+        converted_biosample = self.biosamples_converter.convert(biomaterial)
+        # then
+        self.assertEqual(SampleMatcher(target_biosample), converted_biosample)
+
+    def test_sample_species_from_biomaterial_when_genus_species_missing(self):
+        # given
+        biomaterial = self.__get_biomaterial_by_id('genus-missing-test')
+        target_biosample = self.__create_a_sample(species=None)
+        # when
+        converted_biosample = self.biosamples_converter.convert(biomaterial)
+        # then
+        self.assertEqual(SampleMatcher(target_biosample), converted_biosample)
+
+    def test_sample_species_from_biomaterial_when_genus_species_empty(self):
+        # given
+        biomaterial = self.__get_biomaterial_by_id('genus-empty-test')
+        target_biosample = self.__create_a_sample(species=None)
+        # when
+        converted_biosample = self.biosamples_converter.convert(biomaterial)
+        # then
+        self.assertEqual(SampleMatcher(target_biosample), converted_biosample)
+
+    def test_sample_species_from_biomaterial_when_genus_species_no_ontology(self):
+        # given
+        biomaterial = self.__get_biomaterial_by_id('genus-no-ontology')
+        target_biosample = self.__create_a_sample(species=None)
+        # when
+        converted_biosample = self.biosamples_converter.convert(biomaterial)
+        # then
+        self.assertEqual(SampleMatcher(target_biosample), converted_biosample)
+
+    def test_sample_ncbi_from_biomaterial_ncbi_taxon_id_missing(self):
+        # given
+        biomaterial = self.__get_biomaterial_by_id('ncbi-missing-test')
+        target_biosample = self.__create_a_sample(ncbi_taxon_id=None)
+        # when
+        converted_biosample = self.biosamples_converter.convert(biomaterial)
+        # then
+        self.assertEqual(SampleMatcher(target_biosample), converted_biosample)
+
+    def test_sample_ncbi_from_biomaterial_ncbi_taxon_id_empty(self):
+        # given
+        biomaterial = self.__get_biomaterial_by_id('ncbi-empty-test')
+        target_biosample = self.__create_a_sample(ncbi_taxon_id=None)
+        # when
+        converted_biosample = self.biosamples_converter.convert(biomaterial)
+        # then
+        self.assertEqual(SampleMatcher(target_biosample), converted_biosample)
+
+    def __create_a_sample(
+            self,
+            biomaterial_id='HS_BM_2_cell_line',
             accession='SAMEA6877932',
-            name=sample_name,
+            name='Bone Marrow CD34+ stem/progenitor cells',
+            release_date='2019-07-18T21:12:39.770Z',
+            species='Homo sapiens',
+            ncbi_taxon_id=9606
+    ):
+        biosample = Sample(
+            accession=accession,
+            name=name,
             release=datetime.strptime(release_date, '%Y-%m-%dT%H:%M:%S.%fZ'),
             update=datetime(2020, 6, 12, 14, 26, 37, 998000),
             domain=self.domain,
-            species='Homo sapiens',
-            ncbi_taxon_id=9606,
+            species=species,
+            ncbi_taxon_id=ncbi_taxon_id,
         )
         biosample._append_organism_attribute()
-        self.__create_attributes(biosample,
-                                 {
-                                     'Biomaterial Core - Biomaterial Id': biomaterial_id,
-                                     'HCA Biomaterial Type': 'cell_line',
-                                     'HCA Biomaterial UUID': '501ba65c-0b04-430d-9aad-917935ee3c3c',
-                                     'Is Living': 'yes',
-                                     'Medical History - Smoking History': '20 cigarettes/day for 25 years, stopped 2000',
-                                     'Sex': 'male',
-                                     'project': 'Human Cell Atlas'
-                                 }
-                                 )
-
+        self.__create_attributes(
+            biosample,
+            {
+                'Biomaterial Core - Biomaterial Id': biomaterial_id,
+                'HCA Biomaterial Type': 'cell_line',
+                'HCA Biomaterial UUID': '501ba65c-0b04-430d-9aad-917935ee3c3c',
+                'Is Living': 'yes',
+                'Medical History - Smoking History': '20 cigarettes/day for 25 years, stopped 2000',
+                'Sex': 'male',
+                'project': 'Human Cell Atlas'
+            }
+        )
         return biosample
 
     def __get_biomaterial_by_index(self, index):
         return list(map(lambda attribute: attribute['attributes'], list(self.biomaterials['biomaterials'].values())))[index]
+
+    def __get_biomaterial_by_id(self, biomaterial_id):
+        return self.biomaterials.get('biomaterials', {}).get(biomaterial_id, {}).get('attributes')
 
     @staticmethod
     def __create_attributes(biosample: Sample, attributes: dict):

--- a/tests/unit/resources/biomaterials.json
+++ b/tests/unit/resources/biomaterials.json
@@ -1003,7 +1003,7 @@
         ]
       }
     },
-    "genus-no-ontology": {
+    "genus-no-ontology-label": {
       "attributes": {
         "content": {
           "describedBy": "https://schema.humancellatlas.org/type/biomaterial/14.5.0/cell_line",

--- a/tests/unit/resources/biomaterials.json
+++ b/tests/unit/resources/biomaterials.json
@@ -103,6 +103,108 @@
         ]
       }
     },
+    "5ee74a8d5e315a423810edfc2": {
+      "attributes": {
+        "content": {
+          "describedBy": "https://schema.humancellatlas.org/type/biomaterial/14.5.0/cell_line",
+          "schema_type": "biomaterial",
+          "biomaterial_core": {
+            "biomaterial_id": "BP37d",
+            "ncbi_taxon_id": [
+              9606
+            ],
+            "biosamples_accession": "SAMEA6877932"
+          },
+          "supplier": "AllCells, LLC",
+          "catalog_number": "ABM022F",
+          "catalog_url": "https://www.allcells.com/products/bone-marrow-cd34-stem-progenitor-cells",
+          "type": "stem cell",
+          "sex": "male",
+          "is_living": "yes",
+          "cell_type": {
+            "ontology_label": "CD34-positive, CD38-negative hematopoietic stem cell",
+            "text": "CD34-positive, CD38-negative hematopoietic stem cell",
+            "ontology": "CL:0001024"
+          },
+          "date_established": "2016-08-17",
+          "genus_species": [
+            {
+              "text": "Homo sapiens",
+              "ontology": "NCBITaxon:9606",
+              "ontology_label": "Homo sapiens"
+            }
+          ],
+          "model_organ": {
+            "text": "bone marrow",
+            "ontology": "UBERON:0002371",
+            "ontology_label": "bone marrow"
+          },
+          "medical_history": {
+            "smoking_history": "20 cigarettes/day for 25 years, stopped 2000"
+          }
+        },
+        "submissionDate": "2019-07-18T21:12:39.770Z",
+        "updateDate": "2020-06-12T14:26:37.998Z",
+        "user": null,
+        "lastModifiedUser": "anonymousUser",
+        "type": "Biomaterial",
+        "uuid": {
+          "uuid": "501ba65c-0b04-430d-9aad-917935ee3c3c"
+        },
+        "events": [
+        ],
+        "firstDcpVersion": null,
+        "dcpVersion": "2020-03-05T14:39:16.763Z",
+        "contentLastModified": "2021-04-27T11:00:38.888707Z",
+        "accession": null,
+        "validationState": "Valid",
+        "validationErrors": [
+        ],
+        "isUpdate": false,
+        "linked": true,
+        "_links": {
+          "self": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240"
+          },
+          "biomaterial": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240"
+          },
+          "processing": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/processingEvent"
+          },
+          "draft": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/draftEvent"
+          },
+          "project": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/project",
+            "title": "A single project"
+          },
+          "projects": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/projects",
+            "title": "Access or create projects. Creation can only be done inside a submission envelope"
+          },
+          "inputToProcesses": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/inputToProcesses"
+          },
+          "derivedByProcesses": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/derivedByProcesses"
+          },
+          "submissionEnvelope": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/submissionEnvelope",
+            "title": "A single submission envelope"
+          }
+        }
+      },
+      "links": {
+        "processes": [
+          "5ee74a8e5e315a423810ee3f",
+          "5ee74a8e5e315a423810ee3b"
+        ],
+        "bundleManifests": [
+          "5ee750265e315a423810ee41"
+        ]
+      }
+    },
     "5ee74a8d5e315a423810edf4": {
       "attributes": {
         "content": {
@@ -110,7 +212,6 @@
           "schema_type": "biomaterial",
           "biomaterial_core": {
             "biomaterial_id": "BP37d",
-            "biomaterial_name": "donor5",
             "biomaterial_description": "healthy regular platelet donor, who donated platelet apheresis cone containing peripheral blood mononuclear cells",
             "ncbi_taxon_id": [
               9606

--- a/tests/unit/resources/biomaterials.json
+++ b/tests/unit/resources/biomaterials.json
@@ -399,6 +399,910 @@
           "5ee750265e315a423810ee44"
         ]
       }
+    },
+    "accession-attribute-no-content-test": {
+      "attributes": {
+        "content": {
+          "describedBy": "https://schema.humancellatlas.org/type/biomaterial/14.5.0/cell_line",
+          "schema_type": "biomaterial",
+          "biomaterial_core": {
+            "biomaterial_id": "HS_BM_2_cell_line",
+            "biomaterial_name": "Bone Marrow CD34+ stem/progenitor cells",
+            "ncbi_taxon_id": [
+              9606
+            ]
+          },
+          "supplier": "AllCells, LLC",
+          "catalog_number": "ABM022F",
+          "catalog_url": "https://www.allcells.com/products/bone-marrow-cd34-stem-progenitor-cells",
+          "type": "stem cell",
+          "sex": "male",
+          "is_living": "yes",
+          "cell_type": {
+            "ontology_label": "CD34-positive, CD38-negative hematopoietic stem cell",
+            "text": "CD34-positive, CD38-negative hematopoietic stem cell",
+            "ontology": "CL:0001024"
+          },
+          "date_established": "2016-08-17",
+          "genus_species": [
+            {
+              "text": "Homo sapiens",
+              "ontology": "NCBITaxon:9606",
+              "ontology_label": "Homo sapiens"
+            }
+          ],
+          "model_organ": {
+            "text": "bone marrow",
+            "ontology": "UBERON:0002371",
+            "ontology_label": "bone marrow"
+          },
+          "medical_history": {
+            "smoking_history": "20 cigarettes/day for 25 years, stopped 2000"
+          }
+        },
+        "submissionDate": "2019-07-18T21:12:39.770Z",
+        "updateDate": "2020-06-12T14:26:37.998Z",
+        "user": null,
+        "lastModifiedUser": "anonymousUser",
+        "type": "Biomaterial",
+        "uuid": {
+          "uuid": "501ba65c-0b04-430d-9aad-917935ee3c3c"
+        },
+        "events": [
+        ],
+        "firstDcpVersion": null,
+        "dcpVersion": "2020-03-05T14:39:16.763Z",
+        "contentLastModified": "2021-04-27T11:00:38.888707Z",
+        "accession": "SAMEA6877932",
+        "validationState": "Valid",
+        "validationErrors": [
+        ],
+        "isUpdate": false,
+        "linked": true,
+        "_links": {
+          "self": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240"
+          },
+          "biomaterial": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240"
+          },
+          "processing": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/processingEvent"
+          },
+          "draft": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/draftEvent"
+          },
+          "project": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/project",
+            "title": "A single project"
+          },
+          "projects": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/projects",
+            "title": "Access or create projects. Creation can only be done inside a submission envelope"
+          },
+          "inputToProcesses": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/inputToProcesses"
+          },
+          "derivedByProcesses": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/derivedByProcesses"
+          },
+          "submissionEnvelope": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/submissionEnvelope",
+            "title": "A single submission envelope"
+          }
+        }
+      },
+      "links": {
+        "processes": [
+          "5ee74a8e5e315a423810ee3f",
+          "5ee74a8e5e315a423810ee3b"
+        ],
+        "bundleManifests": [
+          "5ee750265e315a423810ee41"
+        ]
+      }
+    },
+    "accession-attribute-override-test": {
+      "attributes": {
+        "content": {
+          "describedBy": "https://schema.humancellatlas.org/type/biomaterial/14.5.0/cell_line",
+          "schema_type": "biomaterial",
+          "biomaterial_core": {
+            "biomaterial_id": "HS_BM_2_cell_line",
+            "biomaterial_name": "Bone Marrow CD34+ stem/progenitor cells",
+            "ncbi_taxon_id": [
+              9606
+            ],
+            "biosamples_accession": "ACME"
+          },
+          "supplier": "AllCells, LLC",
+          "catalog_number": "ABM022F",
+          "catalog_url": "https://www.allcells.com/products/bone-marrow-cd34-stem-progenitor-cells",
+          "type": "stem cell",
+          "sex": "male",
+          "is_living": "yes",
+          "cell_type": {
+            "ontology_label": "CD34-positive, CD38-negative hematopoietic stem cell",
+            "text": "CD34-positive, CD38-negative hematopoietic stem cell",
+            "ontology": "CL:0001024"
+          },
+          "date_established": "2016-08-17",
+          "genus_species": [
+            {
+              "text": "Homo sapiens",
+              "ontology": "NCBITaxon:9606",
+              "ontology_label": "Homo sapiens"
+            }
+          ],
+          "model_organ": {
+            "text": "bone marrow",
+            "ontology": "UBERON:0002371",
+            "ontology_label": "bone marrow"
+          },
+          "medical_history": {
+            "smoking_history": "20 cigarettes/day for 25 years, stopped 2000"
+          }
+        },
+        "submissionDate": "2019-07-18T21:12:39.770Z",
+        "updateDate": "2020-06-12T14:26:37.998Z",
+        "user": null,
+        "lastModifiedUser": "anonymousUser",
+        "type": "Biomaterial",
+        "uuid": {
+          "uuid": "501ba65c-0b04-430d-9aad-917935ee3c3c"
+        },
+        "events": [
+        ],
+        "firstDcpVersion": null,
+        "dcpVersion": "2020-03-05T14:39:16.763Z",
+        "contentLastModified": "2021-04-27T11:00:38.888707Z",
+        "accession": "SAMEA6877932",
+        "validationState": "Valid",
+        "validationErrors": [
+        ],
+        "isUpdate": false,
+        "linked": true,
+        "_links": {
+          "self": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240"
+          },
+          "biomaterial": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240"
+          },
+          "processing": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/processingEvent"
+          },
+          "draft": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/draftEvent"
+          },
+          "project": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/project",
+            "title": "A single project"
+          },
+          "projects": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/projects",
+            "title": "Access or create projects. Creation can only be done inside a submission envelope"
+          },
+          "inputToProcesses": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/inputToProcesses"
+          },
+          "derivedByProcesses": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/derivedByProcesses"
+          },
+          "submissionEnvelope": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/submissionEnvelope",
+            "title": "A single submission envelope"
+          }
+        }
+      },
+      "links": {
+        "processes": [
+          "5ee74a8e5e315a423810ee3f",
+          "5ee74a8e5e315a423810ee3b"
+        ],
+        "bundleManifests": [
+          "5ee750265e315a423810ee41"
+        ]
+      }
+    },
+    "accession-content-test": {
+      "attributes": {
+        "content": {
+          "describedBy": "https://schema.humancellatlas.org/type/biomaterial/14.5.0/cell_line",
+          "schema_type": "biomaterial",
+          "biomaterial_core": {
+            "biomaterial_id": "HS_BM_2_cell_line",
+            "biomaterial_name": "Bone Marrow CD34+ stem/progenitor cells",
+            "ncbi_taxon_id": [
+              9606
+            ],
+            "biosamples_accession": "SAMEA6877932"
+          },
+          "supplier": "AllCells, LLC",
+          "catalog_number": "ABM022F",
+          "catalog_url": "https://www.allcells.com/products/bone-marrow-cd34-stem-progenitor-cells",
+          "type": "stem cell",
+          "sex": "male",
+          "is_living": "yes",
+          "cell_type": {
+            "ontology_label": "CD34-positive, CD38-negative hematopoietic stem cell",
+            "text": "CD34-positive, CD38-negative hematopoietic stem cell",
+            "ontology": "CL:0001024"
+          },
+          "date_established": "2016-08-17",
+          "genus_species": [
+            {
+              "text": "Homo sapiens",
+              "ontology": "NCBITaxon:9606",
+              "ontology_label": "Homo sapiens"
+            }
+          ],
+          "model_organ": {
+            "text": "bone marrow",
+            "ontology": "UBERON:0002371",
+            "ontology_label": "bone marrow"
+          },
+          "medical_history": {
+            "smoking_history": "20 cigarettes/day for 25 years, stopped 2000"
+          }
+        },
+        "submissionDate": "2019-07-18T21:12:39.770Z",
+        "updateDate": "2020-06-12T14:26:37.998Z",
+        "user": null,
+        "lastModifiedUser": "anonymousUser",
+        "type": "Biomaterial",
+        "uuid": {
+          "uuid": "501ba65c-0b04-430d-9aad-917935ee3c3c"
+        },
+        "events": [
+        ],
+        "firstDcpVersion": null,
+        "dcpVersion": "2020-03-05T14:39:16.763Z",
+        "contentLastModified": "2021-04-27T11:00:38.888707Z",
+        "accession": null,
+        "validationState": "Valid",
+        "validationErrors": [
+        ],
+        "isUpdate": false,
+        "linked": true,
+        "_links": {
+          "self": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240"
+          },
+          "biomaterial": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240"
+          },
+          "processing": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/processingEvent"
+          },
+          "draft": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/draftEvent"
+          },
+          "project": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/project",
+            "title": "A single project"
+          },
+          "projects": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/projects",
+            "title": "Access or create projects. Creation can only be done inside a submission envelope"
+          },
+          "inputToProcesses": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/inputToProcesses"
+          },
+          "derivedByProcesses": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/derivedByProcesses"
+          },
+          "submissionEnvelope": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/submissionEnvelope",
+            "title": "A single submission envelope"
+          }
+        }
+      },
+      "links": {
+        "processes": [
+          "5ee74a8e5e315a423810ee3f",
+          "5ee74a8e5e315a423810ee3b"
+        ],
+        "bundleManifests": [
+          "5ee750265e315a423810ee41"
+        ]
+      }
+    },
+    "accession-missing-test": {
+      "attributes": {
+        "content": {
+          "describedBy": "https://schema.humancellatlas.org/type/biomaterial/14.5.0/cell_line",
+          "schema_type": "biomaterial",
+          "biomaterial_core": {
+            "biomaterial_id": "HS_BM_2_cell_line",
+            "biomaterial_name": "Bone Marrow CD34+ stem/progenitor cells",
+            "ncbi_taxon_id": [
+              9606
+            ]
+          },
+          "supplier": "AllCells, LLC",
+          "catalog_number": "ABM022F",
+          "catalog_url": "https://www.allcells.com/products/bone-marrow-cd34-stem-progenitor-cells",
+          "type": "stem cell",
+          "sex": "male",
+          "is_living": "yes",
+          "cell_type": {
+            "ontology_label": "CD34-positive, CD38-negative hematopoietic stem cell",
+            "text": "CD34-positive, CD38-negative hematopoietic stem cell",
+            "ontology": "CL:0001024"
+          },
+          "date_established": "2016-08-17",
+          "genus_species": [
+            {
+              "text": "Homo sapiens",
+              "ontology": "NCBITaxon:9606",
+              "ontology_label": "Homo sapiens"
+            }
+          ],
+          "model_organ": {
+            "text": "bone marrow",
+            "ontology": "UBERON:0002371",
+            "ontology_label": "bone marrow"
+          },
+          "medical_history": {
+            "smoking_history": "20 cigarettes/day for 25 years, stopped 2000"
+          }
+        },
+        "submissionDate": "2019-07-18T21:12:39.770Z",
+        "updateDate": "2020-06-12T14:26:37.998Z",
+        "user": null,
+        "lastModifiedUser": "anonymousUser",
+        "type": "Biomaterial",
+        "uuid": {
+          "uuid": "501ba65c-0b04-430d-9aad-917935ee3c3c"
+        },
+        "events": [
+        ],
+        "firstDcpVersion": null,
+        "dcpVersion": "2020-03-05T14:39:16.763Z",
+        "contentLastModified": "2021-04-27T11:00:38.888707Z",
+        "accession": null,
+        "validationState": "Valid",
+        "validationErrors": [
+        ],
+        "isUpdate": false,
+        "linked": true,
+        "_links": {
+          "self": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240"
+          },
+          "biomaterial": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240"
+          },
+          "processing": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/processingEvent"
+          },
+          "draft": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/draftEvent"
+          },
+          "project": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/project",
+            "title": "A single project"
+          },
+          "projects": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/projects",
+            "title": "Access or create projects. Creation can only be done inside a submission envelope"
+          },
+          "inputToProcesses": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/inputToProcesses"
+          },
+          "derivedByProcesses": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/derivedByProcesses"
+          },
+          "submissionEnvelope": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/submissionEnvelope",
+            "title": "A single submission envelope"
+          }
+        }
+      },
+      "links": {
+        "processes": [
+          "5ee74a8e5e315a423810ee3f",
+          "5ee74a8e5e315a423810ee3b"
+        ],
+        "bundleManifests": [
+          "5ee750265e315a423810ee41"
+        ]
+      }
+    },
+    "genus-missing-test": {
+      "attributes": {
+        "content": {
+          "describedBy": "https://schema.humancellatlas.org/type/biomaterial/14.5.0/cell_line",
+          "schema_type": "biomaterial",
+          "biomaterial_core": {
+            "biomaterial_id": "HS_BM_2_cell_line",
+            "biomaterial_name": "Bone Marrow CD34+ stem/progenitor cells",
+            "ncbi_taxon_id": [
+              9606
+            ],
+            "biosamples_accession": "SAMEA6877932"
+          },
+          "supplier": "AllCells, LLC",
+          "catalog_number": "ABM022F",
+          "catalog_url": "https://www.allcells.com/products/bone-marrow-cd34-stem-progenitor-cells",
+          "type": "stem cell",
+          "sex": "male",
+          "is_living": "yes",
+          "cell_type": {
+            "ontology_label": "CD34-positive, CD38-negative hematopoietic stem cell",
+            "text": "CD34-positive, CD38-negative hematopoietic stem cell",
+            "ontology": "CL:0001024"
+          },
+          "date_established": "2016-08-17",
+          "model_organ": {
+            "text": "bone marrow",
+            "ontology": "UBERON:0002371",
+            "ontology_label": "bone marrow"
+          },
+          "medical_history": {
+            "smoking_history": "20 cigarettes/day for 25 years, stopped 2000"
+          }
+        },
+        "submissionDate": "2019-07-18T21:12:39.770Z",
+        "updateDate": "2020-06-12T14:26:37.998Z",
+        "user": null,
+        "lastModifiedUser": "anonymousUser",
+        "type": "Biomaterial",
+        "uuid": {
+          "uuid": "501ba65c-0b04-430d-9aad-917935ee3c3c"
+        },
+        "events": [
+        ],
+        "firstDcpVersion": null,
+        "dcpVersion": "2020-03-05T14:39:16.763Z",
+        "contentLastModified": "2021-04-27T11:00:38.888707Z",
+        "accession": null,
+        "validationState": "Valid",
+        "validationErrors": [
+        ],
+        "isUpdate": false,
+        "linked": true,
+        "_links": {
+          "self": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240"
+          },
+          "biomaterial": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240"
+          },
+          "processing": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/processingEvent"
+          },
+          "draft": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/draftEvent"
+          },
+          "project": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/project",
+            "title": "A single project"
+          },
+          "projects": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/projects",
+            "title": "Access or create projects. Creation can only be done inside a submission envelope"
+          },
+          "inputToProcesses": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/inputToProcesses"
+          },
+          "derivedByProcesses": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/derivedByProcesses"
+          },
+          "submissionEnvelope": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/submissionEnvelope",
+            "title": "A single submission envelope"
+          }
+        }
+      },
+      "links": {
+        "processes": [
+          "5ee74a8e5e315a423810ee3f",
+          "5ee74a8e5e315a423810ee3b"
+        ],
+        "bundleManifests": [
+          "5ee750265e315a423810ee41"
+        ]
+      }
+    },
+    "genus-empty-test": {
+      "attributes": {
+        "content": {
+          "describedBy": "https://schema.humancellatlas.org/type/biomaterial/14.5.0/cell_line",
+          "schema_type": "biomaterial",
+          "biomaterial_core": {
+            "biomaterial_id": "HS_BM_2_cell_line",
+            "biomaterial_name": "Bone Marrow CD34+ stem/progenitor cells",
+            "ncbi_taxon_id": [
+              9606
+            ],
+            "biosamples_accession": "SAMEA6877932"
+          },
+          "supplier": "AllCells, LLC",
+          "catalog_number": "ABM022F",
+          "catalog_url": "https://www.allcells.com/products/bone-marrow-cd34-stem-progenitor-cells",
+          "type": "stem cell",
+          "sex": "male",
+          "is_living": "yes",
+          "cell_type": {
+            "ontology_label": "CD34-positive, CD38-negative hematopoietic stem cell",
+            "text": "CD34-positive, CD38-negative hematopoietic stem cell",
+            "ontology": "CL:0001024"
+          },
+          "date_established": "2016-08-17",
+          "genus_species": [],
+          "model_organ": {
+            "text": "bone marrow",
+            "ontology": "UBERON:0002371",
+            "ontology_label": "bone marrow"
+          },
+          "medical_history": {
+            "smoking_history": "20 cigarettes/day for 25 years, stopped 2000"
+          }
+        },
+        "submissionDate": "2019-07-18T21:12:39.770Z",
+        "updateDate": "2020-06-12T14:26:37.998Z",
+        "user": null,
+        "lastModifiedUser": "anonymousUser",
+        "type": "Biomaterial",
+        "uuid": {
+          "uuid": "501ba65c-0b04-430d-9aad-917935ee3c3c"
+        },
+        "events": [
+        ],
+        "firstDcpVersion": null,
+        "dcpVersion": "2020-03-05T14:39:16.763Z",
+        "contentLastModified": "2021-04-27T11:00:38.888707Z",
+        "accession": null,
+        "validationState": "Valid",
+        "validationErrors": [
+        ],
+        "isUpdate": false,
+        "linked": true,
+        "_links": {
+          "self": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240"
+          },
+          "biomaterial": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240"
+          },
+          "processing": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/processingEvent"
+          },
+          "draft": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/draftEvent"
+          },
+          "project": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/project",
+            "title": "A single project"
+          },
+          "projects": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/projects",
+            "title": "Access or create projects. Creation can only be done inside a submission envelope"
+          },
+          "inputToProcesses": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/inputToProcesses"
+          },
+          "derivedByProcesses": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/derivedByProcesses"
+          },
+          "submissionEnvelope": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/submissionEnvelope",
+            "title": "A single submission envelope"
+          }
+        }
+      },
+      "links": {
+        "processes": [
+          "5ee74a8e5e315a423810ee3f",
+          "5ee74a8e5e315a423810ee3b"
+        ],
+        "bundleManifests": [
+          "5ee750265e315a423810ee41"
+        ]
+      }
+    },
+    "genus-no-ontology": {
+      "attributes": {
+        "content": {
+          "describedBy": "https://schema.humancellatlas.org/type/biomaterial/14.5.0/cell_line",
+          "schema_type": "biomaterial",
+          "biomaterial_core": {
+            "biomaterial_id": "HS_BM_2_cell_line",
+            "biomaterial_name": "Bone Marrow CD34+ stem/progenitor cells",
+            "ncbi_taxon_id": [
+              9606
+            ],
+            "biosamples_accession": "SAMEA6877932"
+          },
+          "supplier": "AllCells, LLC",
+          "catalog_number": "ABM022F",
+          "catalog_url": "https://www.allcells.com/products/bone-marrow-cd34-stem-progenitor-cells",
+          "type": "stem cell",
+          "sex": "male",
+          "is_living": "yes",
+          "cell_type": {
+            "ontology_label": "CD34-positive, CD38-negative hematopoietic stem cell",
+            "text": "CD34-positive, CD38-negative hematopoietic stem cell",
+            "ontology": "CL:0001024"
+          },
+          "date_established": "2016-08-17",
+          "genus_species": [
+            {
+            }
+          ],
+          "model_organ": {
+            "text": "bone marrow",
+            "ontology": "UBERON:0002371",
+            "ontology_label": "bone marrow"
+          },
+          "medical_history": {
+            "smoking_history": "20 cigarettes/day for 25 years, stopped 2000"
+          }
+        },
+        "submissionDate": "2019-07-18T21:12:39.770Z",
+        "updateDate": "2020-06-12T14:26:37.998Z",
+        "user": null,
+        "lastModifiedUser": "anonymousUser",
+        "type": "Biomaterial",
+        "uuid": {
+          "uuid": "501ba65c-0b04-430d-9aad-917935ee3c3c"
+        },
+        "events": [
+        ],
+        "firstDcpVersion": null,
+        "dcpVersion": "2020-03-05T14:39:16.763Z",
+        "contentLastModified": "2021-04-27T11:00:38.888707Z",
+        "accession": null,
+        "validationState": "Valid",
+        "validationErrors": [
+        ],
+        "isUpdate": false,
+        "linked": true,
+        "_links": {
+          "self": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240"
+          },
+          "biomaterial": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240"
+          },
+          "processing": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/processingEvent"
+          },
+          "draft": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/draftEvent"
+          },
+          "project": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/project",
+            "title": "A single project"
+          },
+          "projects": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/projects",
+            "title": "Access or create projects. Creation can only be done inside a submission envelope"
+          },
+          "inputToProcesses": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/inputToProcesses"
+          },
+          "derivedByProcesses": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/derivedByProcesses"
+          },
+          "submissionEnvelope": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/submissionEnvelope",
+            "title": "A single submission envelope"
+          }
+        }
+      },
+      "links": {
+        "processes": [
+          "5ee74a8e5e315a423810ee3f",
+          "5ee74a8e5e315a423810ee3b"
+        ],
+        "bundleManifests": [
+          "5ee750265e315a423810ee41"
+        ]
+      }
+    },
+    "ncbi-missing-test": {
+      "attributes": {
+        "content": {
+          "describedBy": "https://schema.humancellatlas.org/type/biomaterial/14.5.0/cell_line",
+          "schema_type": "biomaterial",
+          "biomaterial_core": {
+            "biomaterial_id": "HS_BM_2_cell_line",
+            "biomaterial_name": "Bone Marrow CD34+ stem/progenitor cells",
+            "biosamples_accession": "SAMEA6877932"
+          },
+          "supplier": "AllCells, LLC",
+          "catalog_number": "ABM022F",
+          "catalog_url": "https://www.allcells.com/products/bone-marrow-cd34-stem-progenitor-cells",
+          "type": "stem cell",
+          "sex": "male",
+          "is_living": "yes",
+          "cell_type": {
+            "ontology_label": "CD34-positive, CD38-negative hematopoietic stem cell",
+            "text": "CD34-positive, CD38-negative hematopoietic stem cell",
+            "ontology": "CL:0001024"
+          },
+          "date_established": "2016-08-17",
+          "genus_species": [
+            {
+              "text": "Homo sapiens",
+              "ontology": "NCBITaxon:9606",
+              "ontology_label": "Homo sapiens"
+            }
+          ],
+          "model_organ": {
+            "text": "bone marrow",
+            "ontology": "UBERON:0002371",
+            "ontology_label": "bone marrow"
+          },
+          "medical_history": {
+            "smoking_history": "20 cigarettes/day for 25 years, stopped 2000"
+          }
+        },
+        "submissionDate": "2019-07-18T21:12:39.770Z",
+        "updateDate": "2020-06-12T14:26:37.998Z",
+        "user": null,
+        "lastModifiedUser": "anonymousUser",
+        "type": "Biomaterial",
+        "uuid": {
+          "uuid": "501ba65c-0b04-430d-9aad-917935ee3c3c"
+        },
+        "events": [
+        ],
+        "firstDcpVersion": null,
+        "dcpVersion": "2020-03-05T14:39:16.763Z",
+        "contentLastModified": "2021-04-27T11:00:38.888707Z",
+        "accession": null,
+        "validationState": "Valid",
+        "validationErrors": [
+        ],
+        "isUpdate": false,
+        "linked": true,
+        "_links": {
+          "self": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240"
+          },
+          "biomaterial": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240"
+          },
+          "processing": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/processingEvent"
+          },
+          "draft": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/draftEvent"
+          },
+          "project": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/project",
+            "title": "A single project"
+          },
+          "projects": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/projects",
+            "title": "Access or create projects. Creation can only be done inside a submission envelope"
+          },
+          "inputToProcesses": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/inputToProcesses"
+          },
+          "derivedByProcesses": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/derivedByProcesses"
+          },
+          "submissionEnvelope": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/submissionEnvelope",
+            "title": "A single submission envelope"
+          }
+        }
+      },
+      "links": {
+        "processes": [
+          "5ee74a8e5e315a423810ee3f",
+          "5ee74a8e5e315a423810ee3b"
+        ],
+        "bundleManifests": [
+          "5ee750265e315a423810ee41"
+        ]
+      }
+    },
+    "ncbi-empty-test": {
+      "attributes": {
+        "content": {
+          "describedBy": "https://schema.humancellatlas.org/type/biomaterial/14.5.0/cell_line",
+          "schema_type": "biomaterial",
+          "biomaterial_core": {
+            "biomaterial_id": "HS_BM_2_cell_line",
+            "biomaterial_name": "Bone Marrow CD34+ stem/progenitor cells",
+            "ncbi_taxon_id": [],
+            "biosamples_accession": "SAMEA6877932"
+          },
+          "supplier": "AllCells, LLC",
+          "catalog_number": "ABM022F",
+          "catalog_url": "https://www.allcells.com/products/bone-marrow-cd34-stem-progenitor-cells",
+          "type": "stem cell",
+          "sex": "male",
+          "is_living": "yes",
+          "cell_type": {
+            "ontology_label": "CD34-positive, CD38-negative hematopoietic stem cell",
+            "text": "CD34-positive, CD38-negative hematopoietic stem cell",
+            "ontology": "CL:0001024"
+          },
+          "date_established": "2016-08-17",
+          "genus_species": [
+            {
+              "text": "Homo sapiens",
+              "ontology": "NCBITaxon:9606",
+              "ontology_label": "Homo sapiens"
+            }
+          ],
+          "model_organ": {
+            "text": "bone marrow",
+            "ontology": "UBERON:0002371",
+            "ontology_label": "bone marrow"
+          },
+          "medical_history": {
+            "smoking_history": "20 cigarettes/day for 25 years, stopped 2000"
+          }
+        },
+        "submissionDate": "2019-07-18T21:12:39.770Z",
+        "updateDate": "2020-06-12T14:26:37.998Z",
+        "user": null,
+        "lastModifiedUser": "anonymousUser",
+        "type": "Biomaterial",
+        "uuid": {
+          "uuid": "501ba65c-0b04-430d-9aad-917935ee3c3c"
+        },
+        "events": [
+        ],
+        "firstDcpVersion": null,
+        "dcpVersion": "2020-03-05T14:39:16.763Z",
+        "contentLastModified": "2021-04-27T11:00:38.888707Z",
+        "accession": null,
+        "validationState": "Valid",
+        "validationErrors": [
+        ],
+        "isUpdate": false,
+        "linked": true,
+        "_links": {
+          "self": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240"
+          },
+          "biomaterial": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240"
+          },
+          "processing": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/processingEvent"
+          },
+          "draft": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/draftEvent"
+          },
+          "project": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/project",
+            "title": "A single project"
+          },
+          "projects": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/projects",
+            "title": "Access or create projects. Creation can only be done inside a submission envelope"
+          },
+          "inputToProcesses": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/inputToProcesses"
+          },
+          "derivedByProcesses": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/derivedByProcesses"
+          },
+          "submissionEnvelope": {
+            "href": "https://api.ingest.archive.data.humancellatlas.org/biomaterials/5d30e0c79be88c0008a9b240/submissionEnvelope",
+            "title": "A single submission envelope"
+          }
+        }
+      },
+      "links": {
+        "processes": [
+          "5ee74a8e5e315a423810ee3f",
+          "5ee74a8e5e315a423810ee3b"
+        ],
+        "bundleManifests": [
+          "5ee750265e315a423810ee41"
+        ]
+      }
     }
   }
 }

--- a/tests/unit/resources/biomaterials.json
+++ b/tests/unit/resources/biomaterials.json
@@ -400,7 +400,7 @@
         ]
       }
     },
-    "accession-attribute-no-content-test": {
+    "accession-from-attribute-without-core-accession": {
       "attributes": {
         "content": {
           "describedBy": "https://schema.humancellatlas.org/type/biomaterial/14.5.0/cell_line",
@@ -502,7 +502,7 @@
         ]
       }
     },
-    "accession-attribute-override-test": {
+    "accession-from-attribute-with-core-accession": {
       "attributes": {
         "content": {
           "describedBy": "https://schema.humancellatlas.org/type/biomaterial/14.5.0/cell_line",
@@ -605,7 +605,7 @@
         ]
       }
     },
-    "accession-content-test": {
+    "accession-from-core-without-attribute": {
       "attributes": {
         "content": {
           "describedBy": "https://schema.humancellatlas.org/type/biomaterial/14.5.0/cell_line",

--- a/tests/unit/resources/biomaterials.json
+++ b/tests/unit/resources/biomaterials.json
@@ -1030,6 +1030,8 @@
           "date_established": "2016-08-17",
           "genus_species": [
             {
+              "text": "Homo sapiens",
+              "ontology": "NCBITaxon:9606"
             }
           ],
           "model_organ": {


### PR DESCRIPTION
dcp-824

The biomaterial name property is mandatory for the BioSamples service. If we don't provide it BioSamples can't persist the biomaterial in their database. In this change we try to set the name of the biomaterial first, if that is not present then we use the `biomaterial_id` property. That (`biomaterial_id`) should be present in a biomaterial as it is a mandatory property in the HCA schema.